### PR TITLE
Refactor logging to shared utility

### DIFF
--- a/includes/logger.php
+++ b/includes/logger.php
@@ -1,0 +1,6 @@
+<?php
+function logMessage($message, $file)
+{
+    $timestamp = date('Y-m-d H:i:s');
+    file_put_contents($file, "[$timestamp] $message" . PHP_EOL, FILE_APPEND);
+}

--- a/public/daily/send_abwesenheit_fahrer.php
+++ b/public/daily/send_abwesenheit_fahrer.php
@@ -9,19 +9,16 @@ error_reporting(E_ALL);
 header('Content-Type: text/plain; charset=utf-8');
 
 // Funktion zum Protokollieren von Nachrichten (für Cronjobs geeignet)
-function logMessage($message) {
-    $logFile = __DIR__ . '/send_urlaub_anfragen.log';
-    $timestamp = date('[Y-m-d H:i:s]');
-    file_put_contents($logFile, "{$timestamp} {$message}\n", FILE_APPEND);
-}
+require_once __DIR__ . '/../../includes/logger.php';
+$logFile = __DIR__ . '/send_urlaub_anfragen.log';
 
 // Log-Funktion initialisieren
-logMessage("Skript gestartet.");
+logMessage("Skript gestartet.", $logFile);
 
 // Lock-Datei erstellen, um parallele Ausführung zu verhindern
 $lockFile = '/tmp/send_urlaub_anfragen.lock';
 if (file_exists($lockFile)) {
-    logMessage("Skript läuft bereits.");
+    logMessage("Skript läuft bereits.", $logFile);
     exit;
 }
 file_put_contents($lockFile, 'locked');
@@ -35,9 +32,9 @@ register_shutdown_function(function() use ($lockFile) {
 $dbPath = __DIR__ . '/../../includes/db_connection.php';
 if (file_exists($dbPath)) {
     require_once $dbPath;
-    logMessage("Datenbankverbindung eingebunden.");
+    logMessage("Datenbankverbindung eingebunden.", $logFile);
 } else {
-    logMessage("Fehler: Datenbankverbindungsdatei nicht gefunden: {$dbPath}");
+    logMessage("Fehler: Datenbankverbindungsdatei nicht gefunden: {$dbPath}", $logFile);
     exit;
 }
 
@@ -45,9 +42,9 @@ if (file_exists($dbPath)) {
 $configPath = __DIR__ . '/../../includes/config.php';
 if (file_exists($configPath)) {
     require_once $configPath;
-    logMessage("Konfigurationsdatei eingebunden.");
+    logMessage("Konfigurationsdatei eingebunden.", $logFile);
 } else {
-    logMessage("Fehler: Konfigurationsdatei nicht gefunden: {$configPath}");
+    logMessage("Fehler: Konfigurationsdatei nicht gefunden: {$configPath}", $logFile);
     exit;
 }
 
@@ -61,9 +58,9 @@ if (file_exists($exceptionPath) && file_exists($phpmailerClassPath) && file_exis
     require_once $exceptionPath;
     require_once $phpmailerClassPath;
     require_once $smtpPath;
-    logMessage("PHPMailer-Klassen eingebunden.");
+    logMessage("PHPMailer-Klassen eingebunden.", $logFile);
 } else {
-    logMessage("Fehler: PHPMailer-Klassen nicht gefunden. Prüfe die Pfade.");
+    logMessage("Fehler: PHPMailer-Klassen nicht gefunden. Prüfe die Pfade.", $logFile);
     exit;
 }
 
@@ -72,7 +69,7 @@ use PHPMailer\PHPMailer\Exception;
 
 // Funktion zum Senden von E-Mails
 function sendeEmail($empfaengerEmail, $empfaengerName, $subject, $body) {
-    logMessage("Senden einer E-Mail an: {$empfaengerEmail}");
+    logMessage("Senden einer E-Mail an: {$empfaengerEmail}", $logFile);
     $mail = new PHPMailer(true);
     try {
         $mail->isSMTP();
@@ -93,17 +90,17 @@ function sendeEmail($empfaengerEmail, $empfaengerName, $subject, $body) {
         $mail->AltBody = strip_tags($body);
 
         $mail->send();
-        logMessage("E-Mail erfolgreich gesendet an: {$empfaengerEmail}");
+        logMessage("E-Mail erfolgreich gesendet an: {$empfaengerEmail}", $logFile);
         return true;
     } catch (Exception $e) {
-        logMessage("Fehler beim Senden der E-Mail an {$empfaengerEmail}: {$mail->ErrorInfo}");
+        logMessage("Fehler beim Senden der E-Mail an {$empfaengerEmail}: {$mail->ErrorInfo}", $logFile);
         return false;
     }
 }
 
 // Hauptprozess
 try {
-    logMessage("Starte Hauptprozess für Urlaubsanfragen.");
+    logMessage("Starte Hauptprozess für Urlaubsanfragen.", $logFile);
     
     // Abrufen aller beantragten Urlaube, die noch nicht verarbeitet wurden
     $query = "
@@ -117,7 +114,7 @@ try {
     $stmt->execute();
     $antraege = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    logMessage("Anzahl der unprocessed Urlaubsanträge: " . count($antraege));
+    logMessage("Anzahl der unprocessed Urlaubsanträge: " . count($antraege), $logFile);
 
     foreach ($antraege as $antrag) {
         // Definieren Sie den Empfänger, Betreff und Inhalt der E-Mail
@@ -142,12 +139,12 @@ try {
                 WHERE id = :id
             ");
             $updateStmt->execute(['id' => $antrag['id']]);
-            logMessage("Antrag ID " . $antrag['id'] . " als processed markiert.");
+            logMessage("Antrag ID " . $antrag['id'] . " als processed markiert.", $logFile);
         }
     }
 } catch (Exception $e) {
-    logMessage("Fehler im Hauptprozess: " . $e->getMessage());
+    logMessage("Fehler im Hauptprozess: " . $e->getMessage(), $logFile);
 }
 
-logMessage("Skript beendet.");
+logMessage("Skript beendet.", $logFile);
 ?>

--- a/public/versand.php
+++ b/public/versand.php
@@ -1,6 +1,7 @@
 <?php
 require_once '../includes/head.php';
 require_once '../includes/config.php';
+require_once '../includes/logger.php';
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
@@ -13,11 +14,6 @@ require_once __DIR__ . '/../phpmailer/SMTP.php';
 // Logfile-Pfad
 define('LOGFILE', __DIR__ . '/schulung/versand.log');
 
-// Funktion zum Schreiben ins Logfile
-function logMessage($message) {
-    $timestamp = date("Y-m-d H:i:s");
-    file_put_contents(LOGFILE, "[$timestamp] $message" . PHP_EOL, FILE_APPEND);
-}
 
 /**
  * Einladung versenden + iCalendar‑Anhang
@@ -31,14 +27,14 @@ function logMessage($message) {
  
 // Funktion zum Senden der Einladung
 function sendInvitation($id, $vorname, $email, $praxistagdatum) {
-    logMessage("Versende Einladung an: $email");
+    logMessage("Versende Einladung an: $email", LOGFILE);
 	
 	/* ---------------------------------------------------------------------
 	1) Termin in DateTime wandeln
 	------------------------------------------------------------------ */
     $dateObj = DateTime::createFromFormat('d.m.Y', $praxistagdatum);
     if (!$dateObj) {
-        logMessage("Ungültiges Datumsformat: $praxistagdatum");
+        logMessage("Ungültiges Datumsformat: $praxistagdatum", LOGFILE);
         return false;
     }
 
@@ -140,10 +136,10 @@ ICS;
 
         /* ---------- Abschicken ---------- */
         $mail->send();
-        logMessage("E-Mail erfolgreich an $vorname ($email) gesendet.");
+        logMessage("E-Mail erfolgreich an $vorname ($email) gesendet.", LOGFILE);
         return true;
     } catch (Exception $e) {
-        logMessage("Fehler beim Senden der E-Mail an $email: {$mail->ErrorInfo}");
+        logMessage("Fehler beim Senden der E-Mail an $email: {$mail->ErrorInfo}", LOGFILE);
         return false;
     }
 }
@@ -161,7 +157,7 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
             $stmt->execute([':id' => $id]);
             $teilnehmer = $stmt->fetch(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
-            logMessage("Datenbankfehler: " . $e->getMessage());
+            logMessage("Datenbankfehler: " . $e->getMessage(), LOGFILE);
             die("<p>Fehler bei der Datenbankabfrage.</p>");
         }
 
@@ -191,9 +187,9 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
                         WHERE id = :id";
                     $updateStmt = $pdo->prepare($updateEinladung);
                     $updateStmt->execute([':id' => $id]);
-                    logMessage("letzte_einladung für Teilnehmer-ID $id aktualisiert.");
+                    logMessage("letzte_einladung für Teilnehmer-ID $id aktualisiert.", LOGFILE);
                 } catch (PDOException $e) {
-                    logMessage("Fehler beim Aktualisieren von letzte_einladung: " . $e->getMessage());
+                    logMessage("Fehler beim Aktualisieren von letzte_einladung: " . $e->getMessage(), LOGFILE);
                 }
 
                 session_start();


### PR DESCRIPTION
## Summary
- add `includes/logger.php` providing `logMessage($message, $file)` with timestamped output
- replace ad-hoc logging in cron and email scripts to use the shared logger

## Testing
- `php -l includes/logger.php public/schulung/send_schulung.php public/daily/send_weekly_sales.php public/versand.php public/daily/send_daily_sales.php public/send_schulung.php public/daily/send_urlaub_anfragen.php public/daily/send_abwesenheit_fahrer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5974114e0832ba3ab0b545e2957d2