### PR TITLE
Centralize email sending via helper

### DIFF
--- a/includes/mailer.php
+++ b/includes/mailer.php
@@ -1,0 +1,65 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/../phpmailer/Exception.php';
+require_once __DIR__ . '/../phpmailer/PHPMailer.php';
+require_once __DIR__ . '/../phpmailer/SMTP.php';
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+/**
+ * Send an email using the project SMTP settings.
+ *
+ * @param string $to Recipient email address
+ * @param string $name Recipient name
+ * @param string $subject Email subject
+ * @param string $body HTML email body
+ * @param array  $attachments Array of attachments. Each attachment can be
+ *                            specified as:
+ *                            ['path' => '/path/to/file', 'name' => 'optional_name']
+ *                            or ['string' => $data, 'filename' => 'name.csv',
+ *                                'type' => 'text/csv', 'encoding' => 'base64']
+ *
+ * @return bool True on success, false on failure
+ */
+function sendEmail($to, $name, $subject, $body, $attachments = []) {
+    $mail = new PHPMailer(true);
+    try {
+        $mail->isSMTP();
+        $mail->Host       = SMTP_HOST;
+        $mail->SMTPAuth   = true;
+        $mail->Username   = SMTP_USER;
+        $mail->Password   = SMTP_PASS;
+        $mail->SMTPSecure = SMTP_SECURE;
+        $mail->Port       = SMTP_PORT;
+
+        $mail->setFrom(MAIL_FROM, MAIL_FROM_NAME);
+
+        if (TEST_MODE) {
+            $mail->addAddress(TEST_EMAIL, TEST_NAME);
+        } else {
+            $mail->addAddress($to, $name);
+        }
+
+        $mail->CharSet = 'UTF-8';
+        $mail->isHTML(true);
+        $mail->Subject = $subject;
+        $mail->Body    = $body;
+        $mail->AltBody = strip_tags($body);
+
+        foreach ($attachments as $attachment) {
+            if (isset($attachment['path'])) {
+                $mail->addAttachment($attachment['path'], $attachment['name'] ?? '');
+            } elseif (isset($attachment['string']) && isset($attachment['filename'])) {
+                $type     = $attachment['type'] ?? 'application/octet-stream';
+                $encoding = $attachment['encoding'] ?? 'base64';
+                $mail->addStringAttachment($attachment['string'], $attachment['filename'], $encoding, $type);
+            }
+        }
+
+        $mail->send();
+        return true;
+    } catch (Exception $e) {
+        return false;
+    }
+}

--- a/public/daily/send_abwesenheit_fahrer.php
+++ b/public/daily/send_abwesenheit_fahrer.php
@@ -48,55 +48,7 @@ if (file_exists($configPath)) {
     exit;
 }
 
-// PHPMailer-Klassen einbinden
-$phpmailerPath = __DIR__ . '/../../phpmailer/';
-$exceptionPath = $phpmailerPath . 'Exception.php';
-$phpmailerClassPath = $phpmailerPath . 'PHPMailer.php';
-$smtpPath = $phpmailerPath . 'SMTP.php';
-
-if (file_exists($exceptionPath) && file_exists($phpmailerClassPath) && file_exists($smtpPath)) {
-    require_once $exceptionPath;
-    require_once $phpmailerClassPath;
-    require_once $smtpPath;
-    logMessage("PHPMailer-Klassen eingebunden.", $logFile);
-} else {
-    logMessage("Fehler: PHPMailer-Klassen nicht gefunden. Prüfe die Pfade.", $logFile);
-    exit;
-}
-
-use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\Exception;
-
-// Funktion zum Senden von E-Mails
-function sendeEmail($empfaengerEmail, $empfaengerName, $subject, $body) {
-    logMessage("Senden einer E-Mail an: {$empfaengerEmail}", $logFile);
-    $mail = new PHPMailer(true);
-    try {
-        $mail->isSMTP();
-        $mail->Host = SMTP_HOST;
-        $mail->SMTPAuth = true;
-        $mail->Username = SMTP_USER;
-        $mail->Password = SMTP_PASS;
-        $mail->SMTPSecure = SMTP_SECURE;
-        $mail->Port = SMTP_PORT;
-
-        $mail->CharSet = 'UTF-8';
-        $mail->setFrom(MAIL_FROM, MAIL_FROM_NAME);
-        $mail->addAddress($empfaengerEmail, $empfaengerName);
-
-        $mail->isHTML(true);
-        $mail->Subject = $subject;
-        $mail->Body = $body;
-        $mail->AltBody = strip_tags($body);
-
-        $mail->send();
-        logMessage("E-Mail erfolgreich gesendet an: {$empfaengerEmail}", $logFile);
-        return true;
-    } catch (Exception $e) {
-        logMessage("Fehler beim Senden der E-Mail an {$empfaengerEmail}: {$mail->ErrorInfo}", $logFile);
-        return false;
-    }
-}
+require_once __DIR__ . '/../../includes/mailer.php';
 
 // Hauptprozess
 try {
@@ -131,7 +83,7 @@ try {
         ";
 
         // E-Mail senden
-        if (sendeEmail($to, 'Urlaubsverwalter', $subject, $body)) {
+        if (sendEmail($to, 'Urlaubsverwalter', $subject, $body)) {
             // Aktualisieren des processed-Status nach erfolgreich versendeter E-Mail
             $updateStmt = $pdo->prepare("
                 UPDATE FahrerAbwesenheiten 

--- a/public/daily/send_daily_sales.php
+++ b/public/daily/send_daily_sales.php
@@ -47,24 +47,7 @@ if (file_exists($configPath)) {
     exit;
 }
 
-// PHPMailer-Klassen einbinden
-$phpmailerPath      = __DIR__ . '/../../phpmailer/';
-$exceptionPath      = $phpmailerPath . 'Exception.php';
-$phpmailerClassPath = $phpmailerPath . 'PHPMailer.php';
-$smtpPath           = $phpmailerPath . 'SMTP.php';
-
-if (file_exists($exceptionPath) && file_exists($phpmailerClassPath) && file_exists($smtpPath)) {
-    require_once $exceptionPath;
-    require_once $phpmailerClassPath;
-    require_once $smtpPath;
-    logMessage("PHPMailer-Klassen eingebunden.", $logFile);
-} else {
-    logMessage("Fehler: PHPMailer-Klassen nicht gefunden. Prüfe die Pfade.", $logFile);
-    exit;
-}
-
-use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\Exception;
+require_once __DIR__ . '/../../includes/mailer.php';
 
 // Funktion zum Abrufen der E-Mail-Empfänger
 function getEmailRecipients(PDO $pdo) {
@@ -142,34 +125,6 @@ function getYesterdaySalesWithWorktime(PDO $pdo) {
 }
 
 // Funktion zum Senden von E-Mails
-function sendeEmail($to, $name, $subject, $body) {
-    logMessage("Senden einer E-Mail an: {$to}", $logFile);
-    $mail = new PHPMailer(true);
-    try {
-        $mail->isSMTP();
-        $mail->Host       = SMTP_HOST;
-        $mail->SMTPAuth   = true;
-        $mail->Username   = SMTP_USER;
-        $mail->Password   = SMTP_PASS;
-        $mail->SMTPSecure = SMTP_SECURE;
-        $mail->Port       = SMTP_PORT;
-
-        $mail->CharSet    = 'UTF-8';
-        $mail->setFrom(MAIL_FROM, MAIL_FROM_NAME);
-        $mail->addAddress($to, $name);
-
-        $mail->isHTML(true);
-        $mail->Subject = $subject;
-        $mail->Body    = $body;
-        $mail->AltBody = strip_tags($body);
-
-        $mail->send();
-        logMessage("E-Mail erfolgreich gesendet an: {$to}", $logFile);
-    } catch (Exception $e) {
-        logMessage("Fehler beim Senden der E-Mail: {$mail->ErrorInfo}", $logFile);
-    }
-}
-
 // Hauptprozess
 try {
     logMessage("Starte den Hauptprozess.", $logFile);
@@ -255,7 +210,7 @@ try {
         </div>
         ";
 
-        sendeEmail(
+        sendEmail(
             $recipient['Email'],
             $recipient['Name'],
             'Umsatz- & Arbeitszeitbericht — ' . $dateLabel,

--- a/public/daily/send_urlaub_anfragen.php
+++ b/public/daily/send_urlaub_anfragen.php
@@ -48,55 +48,7 @@ if (file_exists($configPath)) {
     exit;
 }
 
-// PHPMailer-Klassen einbinden
-$phpmailerPath = __DIR__ . '/../../phpmailer/';
-$exceptionPath = $phpmailerPath . 'Exception.php';
-$phpmailerClassPath = $phpmailerPath . 'PHPMailer.php';
-$smtpPath = $phpmailerPath . 'SMTP.php';
-
-if (file_exists($exceptionPath) && file_exists($phpmailerClassPath) && file_exists($smtpPath)) {
-    require_once $exceptionPath;
-    require_once $phpmailerClassPath;
-    require_once $smtpPath;
-    logMessage("PHPMailer-Klassen eingebunden.", $logFile);
-} else {
-    logMessage("Fehler: PHPMailer-Klassen nicht gefunden. Prüfe die Pfade.", $logFile);
-    exit;
-}
-
-use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\Exception;
-
-// Funktion zum Senden von E-Mails
-function sendeEmail($empfaengerEmail, $empfaengerName, $subject, $body) {
-    logMessage("Senden einer E-Mail an: {$empfaengerEmail}", $logFile);
-    $mail = new PHPMailer(true);
-    try {
-        $mail->isSMTP();
-        $mail->Host = SMTP_HOST;
-        $mail->SMTPAuth = true;
-        $mail->Username = SMTP_USER;
-        $mail->Password = SMTP_PASS;
-        $mail->SMTPSecure = SMTP_SECURE;
-        $mail->Port = SMTP_PORT;
-
-        $mail->CharSet = 'UTF-8';
-        $mail->setFrom(MAIL_FROM, MAIL_FROM_NAME);
-        $mail->addAddress($empfaengerEmail, $empfaengerName);
-
-        $mail->isHTML(true);
-        $mail->Subject = $subject;
-        $mail->Body = $body;
-        $mail->AltBody = strip_tags($body);
-
-        $mail->send();
-        logMessage("E-Mail erfolgreich gesendet an: {$empfaengerEmail}", $logFile);
-        return true;
-    } catch (Exception $e) {
-        logMessage("Fehler beim Senden der E-Mail an {$empfaengerEmail}: {$mail->ErrorInfo}", $logFile);
-        return false;
-    }
-}
+require_once __DIR__ . '/../../includes/mailer.php';
 
 // Abrufen aller beantragten Urlaube, die noch nicht verarbeitet wurden
 try {
@@ -152,7 +104,7 @@ foreach ($antraege as $antrag) {
 
     // E-Mail an alle Empfänger senden
     foreach ($empfaengerListe as $empfaenger) {
-        sendeEmail($empfaenger['Email'], $empfaenger['Name'], $subject, $body);
+        sendEmail($empfaenger['Email'], $empfaenger['Name'], $subject, $body);
     }
 
     // Markiere den Antrag als processed


### PR DESCRIPTION
## Summary
- add reusable `includes/mailer.php` with `sendEmail` helper and attachment support
- refactor daily and schulung scripts to use the new mailer helper
- drop duplicated PHPMailer setup across scripts

## Testing
- `php -l includes/mailer.php`
- `php -l public/schulung/send_schulung.php`
- `php -l public/send_schulung.php`
- `php -l public/daily/send_abwesenheit_fahrer.php`
- `php -l public/daily/send_daily_sales.php`
- `php -l public/daily/send_urlaub_anfragen.php`
- `php -l public/daily/send_weekly_sales.php`


------
https://chatgpt.com/codex/tasks/task_e_68b598fe8950832b9de0d2a440b1805c