### PR TITLE
Centralize modal handling

### DIFF
--- a/public/abwesenheit_fahrer.php
+++ b/public/abwesenheit_fahrer.php
@@ -72,6 +72,7 @@ $formatter->setPattern('MMMM yyyy');
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fahrer Abwesenheiten | DRIVE</title>
   <link rel="stylesheet" href="css/styles.css">
+  <script src="js/modal.js"></script>
   <style>
     /* Basisstil für Kalenderzellen */
 	.dashboard-table td {
@@ -296,17 +297,9 @@ $formatter->setPattern('MMMM yyyy');
   <?php include 'modals/add_fahrer_abwesenheit_modal.php'; ?>
 
   <script>
-    function openModal(modalId) {
-      document.getElementById(modalId).style.display = 'flex';
-    }
-    function closeModal(modalId) {
-      document.getElementById(modalId).style.display = 'none';
-    }
-  </script>
-  <script>	
-		document.querySelector('.burger-menu').addEventListener('click', () => {
-			document.querySelector('.nav-links').classList.toggle('active');
-		});
+                document.querySelector('.burger-menu').addEventListener('click', () => {
+                        document.querySelector('.nav-links').classList.toggle('active');
+                });
     </script>
 </body>
 </html>

--- a/public/driver/personal.php
+++ b/public/driver/personal.php
@@ -58,7 +58,8 @@ try {
   <title>Persönliche Daten | DRIVE</title>
   <link rel="stylesheet" href="css/driver-dashboard.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-	<style>
+  <script src="../js/modal.js"></script>
+        <style>
 		body {
 			font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 			background: #f6f8fa;
@@ -382,12 +383,6 @@ try {
   </div>
   
   <script>
-    function openModal(modalId) {
-      document.getElementById(modalId).style.display = 'flex';
-    }
-    function closeModal(modalId) {
-      document.getElementById(modalId).style.display = 'none';
-    }
     // Schließen des Modals durch Klick außerhalb des Inhalts
     window.onclick = function(event) {
       const modal = document.getElementById('urlaubModal');

--- a/public/fahrer.php
+++ b/public/fahrer.php
@@ -47,6 +47,7 @@ $mitteilung = $stmtMsg->fetch(PDO::FETCH_ASSOC);
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fahrerübersicht | DRIVE</title>
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/modal.js"></script>
 </head>
 <body>
     <?php include 'nav.php'; ?>
@@ -132,14 +133,6 @@ $mitteilung = $stmtMsg->fetch(PDO::FETCH_ASSOC);
     </div>
 
     <script>
-        function openModal(modalId) {
-            document.getElementById(modalId).style.display = 'flex';
-        }
-
-        function closeModal(modalId) {
-            document.getElementById(modalId).style.display = 'none';
-        }
-
         document.querySelector('.burger-menu')?.addEventListener('click', () => {
             document.querySelector('.nav-links')?.classList.toggle('active');
         });

--- a/public/fahrer_bearbeiten.php
+++ b/public/fahrer_bearbeiten.php
@@ -123,6 +123,7 @@ $gesamt_urlaubstage = $stmt->fetchColumn();
     <title>Fahrer bearbeiten | DRIVE</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/modal.js"></script>
     <style>
         .form-section {
             margin-bottom: 1.5rem;
@@ -373,21 +374,14 @@ $gesamt_urlaubstage = $stmt->fetchColumn();
 		</div>
 	</div>
 	<script>
-        function openModal(modalId) {
-            document.getElementById(modalId).style.display = 'flex';
-        }
-
-        function closeModal(modalId) {
-            document.getElementById(modalId).style.display = 'none';
-        }
-		function openEditModal(von, bis, grund) {
-			document.getElementById('edit_startdatum').value = von;
-			document.getElementById('edit_enddatum').value = bis;
-			document.getElementById('edit_grund').value = grund;
-			document.getElementById('original_start').value = von;
-			document.getElementById('original_end').value = bis;
-			document.getElementById('editModal').style.display = 'flex';
-		}
+                function openEditModal(von, bis, grund) {
+                        document.getElementById('edit_startdatum').value = von;
+                        document.getElementById('edit_enddatum').value = bis;
+                        document.getElementById('edit_grund').value = grund;
+                        document.getElementById('original_start').value = von;
+                        document.getElementById('original_end').value = bis;
+                        document.getElementById('editModal').style.display = 'flex';
+                }
 
 		function closeEditModal() {
 			document.getElementById('editModal').style.display = 'none';

--- a/public/fahrer_vergleich.php
+++ b/public/fahrer_vergleich.php
@@ -58,6 +58,7 @@ $result_wochentagsumsatz = $stmt_wochentagsumsatz->fetchAll(PDO::FETCH_ASSOC);
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/modal.js"></script>
 </head>
 <body>
   	<?php include 'nav.php'; ?>
@@ -127,14 +128,5 @@ $result_wochentagsumsatz = $stmt_wochentagsumsatz->fetchAll(PDO::FETCH_ASSOC);
         });
     </script>
   </main>
-  <script>
-	function openModal(modalId) {
-		document.getElementById(modalId).style.display = 'flex';
-	}
-
-	function closeModal(modalId) {
-		document.getElementById(modalId).style.display = 'none';
-	}
-</script>
 </body>
 </html>

--- a/public/fahrzeug_overview.php
+++ b/public/fahrzeug_overview.php
@@ -13,6 +13,7 @@ $fahrzeuge = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fahrzeugübersicht | DRIVE</title>
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/modal.js"></script>
 </head>
 <body>
     <?php include 'nav.php'; ?>
@@ -57,14 +58,5 @@ $fahrzeuge = $stmt->fetchAll(PDO::FETCH_ASSOC);
         </table>
     </main>
     <?php include 'modals/add_vehicle_modal.php'; ?>
-    <script>
-        function openModal(modalId) {
-            document.getElementById(modalId).style.display = 'flex';
-        }
-
-        function closeModal(modalId) {
-            document.getElementById(modalId).style.display = 'none';
-        }
-    </script>
 </body>
 </html>

--- a/public/fahrzeuge.php
+++ b/public/fahrzeuge.php
@@ -83,6 +83,7 @@ $wartung_kommend = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fahrzeuge | DRIVE</title>
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/modal.js"></script>
     <style>
         .fahrzeug.limousine {
             background-color: #d4edda; /* Leichtes Grün */
@@ -193,18 +194,9 @@ $wartung_kommend = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <?php include 'modals/modals.php'; ?>
 
     <script>
-        function openModal(modalId) {
-            document.getElementById(modalId).style.display = 'flex';
-        }
-
-        function closeModal(modalId) {
-            document.getElementById(modalId).style.display = 'none';
-        }
-	</script>
-	<script>	
-		document.querySelector('.burger-menu').addEventListener('click', () => {
-			document.querySelector('.nav-links').classList.toggle('active');
-		});
+                document.querySelector('.burger-menu').addEventListener('click', () => {
+                        document.querySelector('.nav-links').classList.toggle('active');
+                });
     </script>
 </body>
 </html>

--- a/public/js/modal.js
+++ b/public/js/modal.js
@@ -1,0 +1,13 @@
+function openModal(id) {
+  const modal = document.getElementById(id);
+  if (modal) {
+    modal.style.display = 'flex';
+  }
+}
+
+function closeModal(id) {
+  const modal = document.getElementById(id);
+  if (modal) {
+    modal.style.display = 'none';
+  }
+}

--- a/public/service.php
+++ b/public/service.php
@@ -38,6 +38,7 @@ try {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Wartungen | DRIVE</title>
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/modal.js"></script>
 </head>
 <body>
     <?php include 'nav.php'; ?>
@@ -84,16 +85,8 @@ try {
         </table>
     </main>
 	
-	<?php include 'modals/add_maintanance_modal.php'; ?>
-	<script>
-	        function openModal(modalId) {
-            document.getElementById(modalId).style.display = 'flex';
-        }
-
-        function closeModal(modalId) {
-            document.getElementById(modalId).style.display = 'none';
-        }
-		
+        <?php include 'modals/add_maintanance_modal.php'; ?>
+        <script>
         document.querySelector('.burger-menu').addEventListener('click', () => {
             document.querySelector('.nav-links').classList.toggle('active');
         });

--- a/public/statistik.php
+++ b/public/statistik.php
@@ -142,8 +142,9 @@ $result_fahrer_unter_264 = $stmt_fahrer_unter_264->fetchAll(PDO::FETCH_ASSOC);
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fahrerstatistik | Drive</title>
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/modal.js"></script>
 </head>
 <body>
 	<?php include 'nav.php'; ?>
@@ -257,14 +258,6 @@ $result_fahrer_unter_264 = $stmt_fahrer_unter_264->fetchAll(PDO::FETCH_ASSOC);
         <?php endforeach; ?>
     </table>
 </main>
-<script>
-	function openModal(modalId) {
-		document.getElementById(modalId).style.display = 'flex';
-	}
-
-	function closeModal(modalId) {
-		document.getElementById(modalId).style.display = 'none';
-	}
-</script>
+</main>
 </body>
 </html>

--- a/public/zentrale_dashboard.php
+++ b/public/zentrale_dashboard.php
@@ -196,8 +196,9 @@ $unreadCount = count($unreadAbwesenheiten);
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <!-- Bisheriges CSS -->
     <link rel="stylesheet" href="css/styles.css">
-    <style>      
-		/* Krankheitszellen */
+    <script src="js/modal.js"></script>
+    <style>
+                /* Krankheitszellen */
 		.dashboard-table .absent-sick {
 		  background-color: #d4edda;
 		  color: #155724;
@@ -367,16 +368,7 @@ $unreadCount = count($unreadAbwesenheiten);
 			</ul>
 		</section>
 	</aside>
-	<?php include 'modals/add_abwesenheit_modal.php'; ?>
-	<script>
-        function openModal(modalId) {
-            document.getElementById(modalId).style.display = 'flex';
-        }
-
-        function closeModal(modalId) {
-            document.getElementById(modalId).style.display = 'none';
-        }
-    </script>
+        <?php include 'modals/add_abwesenheit_modal.php'; ?>
 	<script>
 		function markAsRead(abwesenheitId) {
 			fetch("mark_as_read.php?abwesenheit_id=" + abwesenheitId)


### PR DESCRIPTION
## Summary
- add `public/js/modal.js` providing shared `openModal` and `closeModal`
- remove inline modal functions from various PHP pages and include the new script

## Testing
- `php -l public/service.php`
- `php -l public/fahrzeug_overview.php`
- `php -l public/fahrer_vergleich.php`
- `php -l public/zentrale_dashboard.php`
- `php -l public/fahrer_bearbeiten.php`
- `php -l public/abwesenheit_fahrer.php`
- `php -l public/fahrzeuge.php`
- `php -l public/statistik.php`
- `php -l public/fahrer.php`
- `php -l public/driver/personal.php`

------
https://chatgpt.com/codex/tasks/task_e_68b5a964c220832b9e2454a21f978290