### PR TITLE
feat: centralize workday calculation

### DIFF
--- a/includes/date_utils.php
+++ b/includes/date_utils.php
@@ -1,0 +1,16 @@
+<?php
+function workdaysBetween($start, $end) {
+    $startDate = new DateTime($start);
+    $endDate = new DateTime($end);
+    $workdays = 0;
+
+    while ($startDate <= $endDate) {
+        if (!in_array($startDate->format('N'), [6, 7])) {
+            $workdays++;
+        }
+        $startDate->modify('+1 day');
+    }
+
+    return $workdays;
+}
+?>

--- a/public/export_fahrer_umsatz.php
+++ b/public/export_fahrer_umsatz.php
@@ -1,6 +1,7 @@
 <?php
 require_once '../includes/head.php';
 require('../fpdf/fpdf.php');
+require_once '../includes/date_utils.php';
 
 ob_start(); // Output Buffering starten
 
@@ -95,22 +96,6 @@ foreach ($umsatzDaten as $eintrag) {
 	unset($summe);
 }
 
-function getWorkdays($start_date, $end_date) {
-    $workdays = 0;
-    $current = strtotime($start_date);
-    $end_ts = strtotime($end_date);
-
-    while ($current <= $end_ts) {
-        $dayOfWeek = date('N', $current);
-        // Arbeitstage: Montag (1) bis Freitag (5)
-        if ($dayOfWeek < 6) {
-            $workdays++;
-        }
-        $current = strtotime('+1 day', $current);
-    }
-    return $workdays;
-}
-
 // Krankheits- und Urlaubsstatus mit Zeitraum abrufen
 try {
     // Krankheiten im Zeitraum gruppiert nach Grund mit Min/Max-Daten
@@ -139,7 +124,7 @@ try {
     $urlaubDetails = [];
 }
 
-$werktage = getWorkdays($start_date, $end_date);
+$werktage = workdaysBetween($start_date, $end_date);
 $startDatumFormat = date('d.m.Y', strtotime($start_date));
 $endDatumFormat = date('d.m.Y', strtotime($end_date));
 

--- a/public/zentrale_dashboard.php
+++ b/public/zentrale_dashboard.php
@@ -2,6 +2,7 @@
 // zentrale_dashboard.php
 
 require_once '../includes/head.php';
+require_once '../includes/date_utils.php';
 require_once 'modals/process_abwesenheit.php';
 
 // PHP-Fehleranzeige aktivieren
@@ -137,23 +138,6 @@ foreach ($upcomingVacations as $vacation) {
 
 if ($currentVacation) {
     $groupedVacations[] = $currentVacation;
-}
-
-function calculateWorkdays($startDate, $endDate) {
-    $start = new DateTime($startDate);
-    $end = new DateTime($endDate);
-    $workdays = 0;
-
-    // Schleife über alle Tage im Zeitraum
-    while ($start <= $end) {
-        // Prüfen, ob der Tag ein Arbeitstag ist (kein Wochenende)
-        if (!in_array($start->format('N'), [6, 7])) { // 6 = Samstag, 7 = Sonntag
-            $workdays++;
-        }
-        $start->modify('+1 day'); // Zum nächsten Tag
-    }
-
-    return $workdays;
 }
 
 // Ungelesene Krankmeldungen für den aktuellen Benutzer ermitteln
@@ -341,7 +325,7 @@ $unreadCount = count($unreadAbwesenheiten);
 			<ul>
 				<?php foreach ($groupedVacations as $vacation): ?>
 					<?php 
-						$workdays = calculateWorkdays($vacation['startdatum'], $vacation['enddatum']); 
+                                            $workdays = workdaysBetween($vacation['startdatum'], $vacation['enddatum']);
 						$age = $vacation['geburtsdatum'] 
 							? calculateAge($vacation['geburtsdatum'], $vacation['startdatum']) 
 							: '-'; 


### PR DESCRIPTION
## Summary
- add shared date utility with `workdaysBetween`
- use `workdaysBetween` in export_fahrer_umsatz and zentrale_dashboard

## Testing
- `php -l includes/date_utils.php`
- `php -l public/export_fahrer_umsatz.php`
- `php -l public/zentrale_dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5ad2f28e4832ba95e2c7a38800e1d