### PR TITLE
Fix database include path for absence notification script

### DIFF
--- a/cron/send_abwesenheit_fahrer.php
+++ b/cron/send_abwesenheit_fahrer.php
@@ -29,7 +29,7 @@ register_shutdown_function(function() use ($lockFile) {
 });
 
 // Datenbankverbindung einbinden
-$dbPath = __DIR__ . '/../includes/db_connection.php';
+$dbPath = __DIR__ . '/../includes/db.php';
 if (file_exists($dbPath)) {
     require_once $dbPath;
     logMessage("Datenbankverbindung eingebunden.", $logFile);


### PR DESCRIPTION
## Summary
- fix `send_abwesenheit_fahrer.php` to use `db.php` for database connection
- confirm other scripts already include the correct database bootstrap

## Testing
- `php -l cron/send_abwesenheit_fahrer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b68afee060832bb8d60bdbc004c207