### PR TITLE
Add message tables with permissions

### DIFF
--- a/migrate.php
+++ b/migrate.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/includes/db.php';
+
+$dir = __DIR__ . '/migrations';
+$files = glob($dir . '/*.sql');
+sort($files);
+
+foreach ($files as $file) {
+    $sql = file_get_contents($file);
+    echo "Applying migration: " . basename($file) . PHP_EOL;
+    try {
+        $pdo->exec($sql);
+        echo "Done" . PHP_EOL;
+    } catch (PDOException $e) {
+        echo "Failed: " . $e->getMessage() . PHP_EOL;
+    }
+}
+?>

--- a/migrations/2024090201_create_messages.sql
+++ b/migrations/2024090201_create_messages.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS messages (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    sender_id INT NOT NULL,
+    recipient_id INT NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    read_at TIMESTAMP NULL DEFAULT NULL,
+    CONSTRAINT fk_messages_sender FOREIGN KEY (sender_id) REFERENCES Benutzer(BenutzerID),
+    CONSTRAINT fk_messages_recipient FOREIGN KEY (recipient_id) REFERENCES Benutzer(BenutzerID)
+);

--- a/migrations/2024090202_create_message_permissions.sql
+++ b/migrations/2024090202_create_message_permissions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS message_permissions (
+    driver_id INT NOT NULL,
+    recipient_id INT NOT NULL,
+    PRIMARY KEY (driver_id, recipient_id),
+    CONSTRAINT fk_msg_perm_driver FOREIGN KEY (driver_id) REFERENCES Fahrer(FahrerID),
+    CONSTRAINT fk_msg_perm_recipient FOREIGN KEY (recipient_id) REFERENCES Benutzer(BenutzerID)
+);


### PR DESCRIPTION
## Summary
- add SQL migrations for `messages` table linking senders and recipients to `Benutzer`
- add `message_permissions` table associating `Fahrer` with permitted recipients
- include helper script to execute migrations

## Testing
- `php migrate.php` *(fails: SQLSTATE[HY000] [2002] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b68ee9b478832ba546af27f253bfb3