### PR TITLE
Add driver message sending page

### DIFF
--- a/public/driver/send_message.php
+++ b/public/driver/send_message.php
@@ -1,0 +1,72 @@
+<?php
+require_once '../../includes/bootstrap.php';
+
+if (!isDriver()) {
+    header('Location: ../index.php');
+    exit;
+}
+
+$driverId = $_SESSION['user_id'];
+
+// Permitted recipients for this driver
+$permStmt = $pdo->prepare(
+    'SELECT mp.recipient_id, b.Name
+     FROM message_permissions mp
+     JOIN Benutzer b ON mp.recipient_id = b.BenutzerID
+     WHERE mp.driver_id = ?
+     ORDER BY b.Name'
+);
+$permStmt->execute([$driverId]);
+$recipients = $permStmt->fetchAll(PDO::FETCH_ASSOC);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $recipientId = (int)($_POST['recipient_id'] ?? 0);
+    $subject = trim($_POST['subject'] ?? '');
+    $body = trim($_POST['body'] ?? '');
+
+    $allowed = array_column($recipients, 'recipient_id');
+    if (!in_array($recipientId, $allowed, true)) {
+        die('Ungültiger Empfänger.');
+    }
+
+    if ($subject === '' || $body === '') {
+        die('Betreff und Nachricht dürfen nicht leer sein.');
+    }
+
+    $insert = $pdo->prepare(
+        'INSERT INTO messages (sender_id, recipient_id, subject, body)
+         VALUES (?, ?, ?, ?)'
+    );
+    $insert->execute([$driverId, $recipientId, $subject, $body]);
+
+    header('Location: dashboard.php?message_sent=1');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Nachricht senden</title>
+    <link rel="stylesheet" href="css/index.css">
+</head>
+<body>
+<?php include 'driver-nav.php'; ?>
+<div class="wrapper">
+    <h1>Nachricht senden</h1>
+    <form method="post">
+        <label for="recipient">Empfänger:</label>
+        <select name="recipient_id" id="recipient" required>
+            <?php foreach ($recipients as $r): ?>
+                <option value="<?= $r['recipient_id'] ?>"><?= htmlspecialchars($r['Name']) ?></option>
+            <?php endforeach; ?>
+        </select>
+        <label for="subject">Betreff:</label>
+        <input type="text" name="subject" id="subject" required>
+        <label for="body">Nachricht:</label>
+        <textarea name="body" id="body" required></textarea>
+        <button type="submit">Senden</button>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add driver messaging page with session-based permissions
- Validate permitted recipients and insert messages

## Testing
- `php -l public/driver/send_message.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6969c8654832ba4458ae903e07af9