### PR TITLE
Highlight current page in navigation menus

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -191,7 +191,7 @@ function hasRole(string $role, $sekundarRolle): bool
 /**
  * Build a menu from the provided items filtering by user roles.
  */
-function buildMenu(array $items, array $userRoles): string
+function buildMenu(array $items, array $userRoles, string $currentPath = ''): string
 {
     $html = '<ul>';
     foreach ($items as $item) {
@@ -214,10 +214,17 @@ function buildMenu(array $items, array $userRoles): string
         $html .= "<li$liClass>";
         $url = $item['url'] ?? '#';
         $label = htmlspecialchars($item['label'], ENT_QUOTES, 'UTF-8');
-        $aClass = $hasChildren ? ' class="dropdown-toggle"' : '';
-        $html .= '<a href="' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '"' . $aClass . '>' . $label . '</a>';
+        $aClasses = [];
         if ($hasChildren) {
-            $childHtml = buildMenu($item['children'], $userRoles);
+            $aClasses[] = 'dropdown-toggle';
+        }
+        if ($currentPath !== '' && basename($url) === $currentPath) {
+            $aClasses[] = 'active';
+        }
+        $aClassAttr = $aClasses ? ' class="' . implode(' ', $aClasses) . '"' : '';
+        $html .= '<a href="' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '"' . $aClassAttr . '>' . $label . '</a>';
+        if ($hasChildren) {
+            $childHtml = buildMenu($item['children'], $userRoles, $currentPath);
             $html .= str_replace('<ul>', '<ul class="dropdown-menu">', $childHtml);
         }
         $html .= '</li>';
@@ -230,7 +237,7 @@ function buildMenu(array $items, array $userRoles): string
 /**
  * Render navigation menu for the given role context.
  */
-function renderMenu($currentRole, $secondaryRoles, $context = 'top')
+function renderMenu($currentRole, $secondaryRoles, $context = 'top', $currentPath = '')
 {
     global $menuEntries;
 
@@ -251,7 +258,7 @@ function renderMenu($currentRole, $secondaryRoles, $context = 'top')
         return ($item['context'] ?? 'top') === $context;
     });
 
-    echo '<nav>' . buildMenu($items, $userRoles) . '</nav>';
+    echo '<nav>' . buildMenu($items, $userRoles, $currentPath) . '</nav>';
 }
 
 ?>

--- a/public/driver/bottom_nav.php
+++ b/public/driver/bottom_nav.php
@@ -1,41 +1,14 @@
 <?php
-// Aktuelle Seite ermitteln
+require_once '../../includes/navigation.php';
 $currentPage = basename($_SERVER['PHP_SELF']);
 ?>
-
 <div class="floating-nav">
-    <nav>
-        <ul>
-            <li>
-                <a href="personal.php" class="<?= $currentPage === 'personal.php' ? 'active' : '' ?>">
-                    <i class="fas fa-user"></i>
-                    Persönliches
-                </a>
-            </li>
-            <li>
-                <a href="fahrzeug.php" class="<?= $currentPage === 'fahrzeug.php' ? 'active' : '' ?>">
-                    <i class="fas fa-car"></i>
-                    Fahrzeug
-                </a>
-            </li>
-            <li>
-                <a href="dashboard.php" class="<?= $currentPage === 'dashboard.php' ? 'active' : '' ?>">
-                    <i class="fas fa-home"></i>
-                    Dashboard
-                </a>
-            </li>
-            <li>
-                <a href="umsatz_erfassen.php" class="<?= $currentPage === 'umsatz_erfassen.php' ? 'active' : '' ?>">
-                    <i class="fas fa-euro-sign"></i>
-                    Umsatz
-                </a>
-            </li>
-            <li>
-                <a href="logout.php" class="<?= $currentPage === 'logout.php' ? 'active' : '' ?>">
-                    <i class="fas fa-sign-out-alt"></i>
-                    Logout
-                </a>
-            </li>
-        </ul>
-    </nav>
+    <?php
+    renderMenu(
+        $_SESSION['rolle'] ?? '',
+        $sekundarRolle ?? '',
+        'bottom',
+        $currentPage
+    );
+    ?>
 </div>

--- a/public/nav.php
+++ b/public/nav.php
@@ -1,8 +1,10 @@
 <?php
 require_once '../includes/navigation.php';
+$currentPage = basename($_SERVER['PHP_SELF']);
 renderMenu(
     $_SESSION['rolle'] ?? '',
     $sekundarRolle ?? '',
-    'top'
+    'top',
+    $currentPage
 );
 ?>


### PR DESCRIPTION
## Summary
- Add optional current path parameter to `renderMenu` and propagate to menu builder
- Mark navigation links as active when their URL matches the current page
- Replace page-specific driver bottom navigation with generic `renderMenu` call

## Testing
- `php -l includes/navigation.php`
- `php -l public/nav.php`
- `php -l public/driver/bottom_nav.php`


------
https://chatgpt.com/codex/tasks/task_e_68b69b7b77b0832bb0fa3a95b88a0504