### PR TITLE
Fix nav menu list styling and class usage

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -193,7 +193,7 @@ function hasRole(string $role, $sekundarRolle): bool
  */
 function buildMenu(array $items, array $userRoles, string $currentPath = ''): string
 {
-    $html = '<ul>';
+    $html = '<ul class="nav-links">';
     foreach ($items as $item) {
         $roles = $item['roles'] ?? [];
         $allowed = empty($roles);
@@ -225,7 +225,7 @@ function buildMenu(array $items, array $userRoles, string $currentPath = ''): st
         $html .= '<a href="' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '"' . $aClassAttr . '>' . $label . '</a>';
         if ($hasChildren) {
             $childHtml = buildMenu($item['children'], $userRoles, $currentPath);
-            $html .= str_replace('<ul>', '<ul class="dropdown-menu">', $childHtml);
+            $html .= str_replace('<ul class="nav-links">', '<ul class="dropdown-menu">', $childHtml);
         }
         $html .= '</li>';
     }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -54,6 +54,9 @@ nav {
     display: flex;
     align-items: center;
     position: relative;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .nav-links a {
@@ -172,6 +175,8 @@ nav {
         height: 100vh;
         background-color: var(--color-nav-bg);
         color: #ffffff;
+        list-style: none;
+        margin: 0;
         padding: 20px;
         transition: right var(--transition-speed) ease-in-out;
         z-index: 2000;


### PR DESCRIPTION
## Summary
- Build navigation lists with `nav-links` class and preserve dropdown handling
- Reset default list styles for `.nav-links` to remove bullets and spacing

## Testing
- `php -l includes/navigation.php`
- `php public/nav.php`


------
https://chatgpt.com/codex/tasks/task_e_68b69dd55648832bb63e7695f9403415