### PR TITLE
Use global flex modals with 80vh content

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -382,6 +382,7 @@ input:focus, select:focus {
  * MODAL
  *********************************************/
 
+
 .modal {
   display: none;
   position: fixed;
@@ -389,8 +390,10 @@ input:focus, select:focus {
   left: 0;
   top: 0;
   width: 100%;
+  height: 100vh;
+  align-items: center;
+  justify-content: center;
   background-color: rgba(0,0,0,0.5);
-  overflow: auto;
 }
 
 .modal-content {
@@ -401,7 +404,7 @@ input:focus, select:focus {
   border-radius: 15px; /* EYE CANDY: rundere Ecken */
   width: 95%;
   color: var(--color-text);
-  max-height: 90%;
+  max-height: 80vh;
   overflow-y: auto;
   box-shadow: 0 4px 12px rgba(0,0,0,0.2);
   transition: transform var(--transition-speed);

--- a/public/driver/personal.php
+++ b/public/driver/personal.php
@@ -133,29 +133,7 @@ try {
 			background-color: #0056b3;
 		}
 
-		.modal {
-			display: none;
-			position: fixed;
-			z-index: 1000;
-			left: 0;
-			top: 0;
-			width: 100%;
-			height: 100%;
-			background-color: rgba(0,0,0,0.5);
-			justify-content: center;
-			align-items: center;
-		}
-
-		.modal-content {
-			background-color: #fff;
-			padding: 30px;
-			border-radius: 10px;
-			width: 90%;
-			max-width: 500px;
-			box-shadow: 0 5px 15px rgba(0,0,0,0.3);
-			animation: fadeIn 0.4s ease;
-			position: relative;
-		}
+                /* Modal styles are handled globally in public/css/styles.css */
 
 		.close {
 			position: absolute;

--- a/public/modals/add_fahrer_abwesenheit_modal.php
+++ b/public/modals/add_fahrer_abwesenheit_modal.php
@@ -1,5 +1,5 @@
 <!-- modals/add_fahrer_abwesenheit_modal.php -->
-<div id="fahrerAbwesenheitModal" class="modal" style="display: none;">
+<div id="fahrerAbwesenheitModal" class="modal">
   <div class="modal-content">
     <span onclick="closeModal('fahrerAbwesenheitModal')" class="close">&times;</span>
     <h2>Abwesenheit eintragen</h2>
@@ -77,28 +77,7 @@
 </script>
 
 <style>
-  /* Einfaches Modal-Design */
-  .modal {
-    display: none; /* Hidden by default */
-    position: fixed; 
-    z-index: 1; 
-    left: 0;
-    top: 0;
-    width: 100%; 
-    height: 100%; 
-    overflow: auto; 
-    background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
-  }
-
-  .modal-content {
-    background-color: #fefefe;
-    margin: 10% auto; 
-    padding: 20px;
-    border: 1px solid #888;
-    width: 50%; 
-    border-radius: 8px;
-  }
-
+  /* Modal styles now handled globally */
   .close {
     color: #aaa;
     float: right;


### PR DESCRIPTION
## Summary
- Center modals with flexbox and viewport-height sizing
- Limit modal content height to 80vh for consistent scrolling
- Remove inline modal styles from driver personal and absence modal to rely on global CSS

## Testing
- `php -l public/driver/personal.php`
- `php -l public/modals/add_fahrer_abwesenheit_modal.php`
- `php -l public/fahrer.php`
- `php -l public/service.php`
- `curl -I http://127.0.0.1:8000/fahrer.php`
- `curl -I http://127.0.0.1:8000/service.php`
- `curl -I http://127.0.0.1:8000/modals/add_fahrer_abwesenheit_modal.php` *(fails: missing database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a0609028832b9bc450444ba0141f