### PR TITLE
Add date field and validate admin absence entries

### DIFF
--- a/public/verwaltung_abwesenheit.php
+++ b/public/verwaltung_abwesenheit.php
@@ -149,7 +149,9 @@ function getAbwesenheitsKlasse($typ) {
     function updateFormFields() {
       const typ = document.getElementById('typ').value;
       document.getElementById('zeitraum').style.display = (typ === 'Urlaub' || typ === 'Krank' || typ === 'Kind Krank') ? 'block' : 'none';
-      document.getElementById('uhrzeit_eintrag').style.display = (typ === 'Kommt später' || typ === 'Geht eher') ? 'block' : 'none';
+      const showTime = (typ === 'Kommt später' || typ === 'Geht eher');
+      document.getElementById('uhrzeit_eintrag').style.display = showTime ? 'block' : 'none';
+      document.getElementById('zeitpunkt_datum').style.display = showTime ? 'inline-block' : 'none';
       document.getElementById('zeitspanne').style.display = (typ === 'Unterbrechung') ? 'block' : 'none';
     }
   </script>
@@ -296,10 +298,12 @@ function getAbwesenheitsKlasse($typ) {
 			<input type="date" name="bis_datum"><br><br>
 		  </div>
 
-		  <div id="uhrzeit_eintrag" style="display:none">
-			<label>Uhrzeit:</label>
-			<input type="time" name="zeitpunkt"><br><br>
-		  </div>
+                  <div id="uhrzeit_eintrag" style="display:none">
+                        <label>Datum:</label>
+                        <input type="date" name="zeitpunkt_datum" id="zeitpunkt_datum"><br>
+                        <label>Uhrzeit:</label>
+                        <input type="time" name="zeitpunkt"><br><br>
+                  </div>
 
 		  <div id="zeitspanne" style="display:none">
 			<label>Datum:</label>

--- a/public/verwaltung_abwesenheit_eintragen.php
+++ b/public/verwaltung_abwesenheit_eintragen.php
@@ -37,11 +37,18 @@ if (in_array($typ, ['Urlaub', 'Krank', 'Kind Krank'])) {
         ];
     }
 } elseif (in_array($typ, ['Kommt später', 'Geht eher'])) {
-    $datum = $_POST['von_datum'] ?? $_POST['tag_zeitspanne'];
+    $datum = $_POST['zeitpunkt_datum'] ?? null;
     $zeit = $_POST['zeitpunkt'] ?? null;
 
     if (!$datum || !$zeit) {
         die("Fehlendes Datum oder Uhrzeit.");
+    }
+
+    $datumObj = DateTime::createFromFormat('Y-m-d', $datum);
+    $zeitObj = DateTime::createFromFormat('H:i', $zeit);
+
+    if (!$datumObj || $datumObj->format('Y-m-d') !== $datum || !$zeitObj || $zeitObj->format('H:i') !== $zeit) {
+        die("Ungültiges Datum oder Uhrzeit.");
     }
 
     $eintraege[] = [
@@ -57,6 +64,14 @@ if (in_array($typ, ['Urlaub', 'Krank', 'Kind Krank'])) {
 
     if (!$datum || !$von || !$bis) {
         die("Fehlende Zeitangaben.");
+    }
+
+    $datumObj = DateTime::createFromFormat('Y-m-d', $datum);
+    $vonObj = DateTime::createFromFormat('H:i', $von);
+    $bisObj = DateTime::createFromFormat('H:i', $bis);
+
+    if (!$datumObj || $datumObj->format('Y-m-d') !== $datum || !$vonObj || $vonObj->format('H:i') !== $von || !$bisObj || $bisObj->format('H:i') !== $bis) {
+        die("Ungültiges Datum oder Uhrzeit.");
     }
 
     $eintraege[] = [


### PR DESCRIPTION
## Summary
- show a date input for 'Kommt später' or 'Geht eher' absence types
- validate date and time when saving single-time and span-based absences

## Testing
- `php -l public/verwaltung_abwesenheit.php`
- `php -l public/verwaltung_abwesenheit_eintragen.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6acf62470832b87d0cf5234a6621d