### PR TITLE
Handle partial absences with codes and color styles

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -396,6 +396,25 @@ input:focus, select:focus {
   background-color: rgba(0,0,0,0.5);
 }
 
+/* Abwesenheitstypen */
+.absent-yellow {
+  background-color: #fff3cd;
+  color: #856404;
+  font-weight: bold;
+}
+
+.absent-orange {
+  background-color: #ffe5b4;
+  color: #7a3e00;
+  font-weight: bold;
+}
+
+.absent-purple {
+  background-color: #e2d6f5;
+  color: #4b0082;
+  font-weight: bold;
+}
+
 .modal-content {
   background-color: #ffffff;
   margin: 5% auto;

--- a/public/verwaltung_abwesenheit.php
+++ b/public/verwaltung_abwesenheit.php
@@ -132,8 +132,33 @@ function getAbwesenheitsKlasse($typ) {
             return 'absent-green';
         case 'Urlaub':
             return 'absent-blue';
+        case 'Kommt später':
+            return 'absent-yellow';
+        case 'Geht eher':
+            return 'absent-orange';
+        case 'Unterbrechung':
+            return 'absent-purple';
         default:
             return 'absent-red';
+    }
+}
+
+function getAbwesenheitsKuerzel($typ) {
+    switch ($typ) {
+        case 'Krank':
+            return 'KR';
+        case 'Kind Krank':
+            return 'KK';
+        case 'Urlaub':
+            return 'UR';
+        case 'Kommt später':
+            return 'LS';
+        case 'Geht eher':
+            return 'GE';
+        case 'Unterbrechung':
+            return 'UB';
+        default:
+            return '?';
     }
 }
 ?>
@@ -255,8 +280,8 @@ function getAbwesenheitsKlasse($typ) {
 
 				foreach ($abwesenheiten as $a) {
 				  if ($a['mitarbeiter_id'] == $person['BenutzerID'] && $a['datum'] == $date['date']) {
-					$cellClass = getAbwesenheitsKlasse($a['typ']);
-					$cellText = $a['typ'][0];
+                                        $cellClass = getAbwesenheitsKlasse($a['typ']);
+                                        $cellText = getAbwesenheitsKuerzel($a['typ']);
 					break;
 				  }
 				}


### PR DESCRIPTION
## Summary
- Add CSS class mapping for late start, early leave, and interruption absences
- Show clear two-letter codes for all absence types in calendar
- Provide yellow, orange, and purple styles for new absence types

## Testing
- `php -l public/verwaltung_abwesenheit.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6ade9659c832ba1dcd44df31d488c