### PR TITLE
Centralize absence type definitions

### DIFF
--- a/includes/absencetypes.php
+++ b/includes/absencetypes.php
@@ -1,0 +1,18 @@
+<?php
+$ABSENCE_TYPES = [
+    'period' => ['Urlaub', 'Krank', 'Kind Krank'],
+    'time_point' => ['Kommt später', 'Geht eher'],
+    'time_range' => ['Unterbrechung'],
+];
+
+$ABSENCE_TYPE_LABELS = [
+    'Urlaub' => 'Urlaub',
+    'Krank' => 'Krank',
+    'Kind Krank' => 'Kind Krank',
+    'Kommt später' => 'Kommt später',
+    'Geht eher' => 'Geht eher',
+    'Unterbrechung' => 'Abwesend über den Tag',
+];
+
+$ALL_ABSENCE_TYPES = array_merge(...array_values($ABSENCE_TYPES));
+?>

--- a/public/verwaltung_abwesenheit.php
+++ b/public/verwaltung_abwesenheit.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../includes/bootstrap.php';
+require_once '../includes/absencetypes.php';
 session_start();
 
 // PHP-Fehleranzeige aktivieren
@@ -171,13 +172,17 @@ function getAbwesenheitsKuerzel($typ) {
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <link rel="stylesheet" href="css/styles.css">
   <script>
+    const typesWithPeriod = <?= json_encode($ABSENCE_TYPES['period']); ?>;
+    const typesWithTimePoint = <?= json_encode($ABSENCE_TYPES['time_point']); ?>;
+    const typesWithTimeRange = <?= json_encode($ABSENCE_TYPES['time_range']); ?>;
+
     function updateFormFields() {
       const typ = document.getElementById('typ').value;
-      document.getElementById('zeitraum').style.display = (typ === 'Urlaub' || typ === 'Krank' || typ === 'Kind Krank') ? 'block' : 'none';
-      const showTime = (typ === 'Kommt später' || typ === 'Geht eher');
+      document.getElementById('zeitraum').style.display = typesWithPeriod.includes(typ) ? 'block' : 'none';
+      const showTime = typesWithTimePoint.includes(typ);
       document.getElementById('uhrzeit_eintrag').style.display = showTime ? 'block' : 'none';
       document.getElementById('zeitpunkt_datum').style.display = showTime ? 'inline-block' : 'none';
-      document.getElementById('zeitspanne').style.display = (typ === 'Unterbrechung') ? 'block' : 'none';
+      document.getElementById('zeitspanne').style.display = typesWithTimeRange.includes(typ) ? 'block' : 'none';
     }
   </script>
   <style>
@@ -306,15 +311,12 @@ function getAbwesenheitsKuerzel($typ) {
 			<?php endforeach; ?>
 		  </select><br><br>
 
-		  <label for="typ">Typ:</label>
-		  <select name="typ" id="typ" onchange="updateFormFields()" required>
-			<option value="Urlaub">Urlaub</option>
-			<option value="Krank">Krank</option>
-			<option value="Kind Krank">Kind Krank</option>
-			<option value="Kommt später">Kommt später</option>
-			<option value="Geht eher">Geht eher</option>
-			<option value="Unterbrechung">Abwesend über den Tag</option>
-		  </select><br><br>
+                  <label for="typ">Typ:</label>
+                  <select name="typ" id="typ" onchange="updateFormFields()" required>
+                        <?php foreach ($ALL_ABSENCE_TYPES as $type): ?>
+                          <option value="<?= $type ?>"><?= htmlspecialchars($ABSENCE_TYPE_LABELS[$type]) ?></option>
+                        <?php endforeach; ?>
+                  </select><br><br>
 
 		  <div id="zeitraum" style="display:none">
 			<label>Von (Datum):</label>

--- a/public/verwaltung_abwesenheit_eintragen.php
+++ b/public/verwaltung_abwesenheit_eintragen.php
@@ -1,5 +1,6 @@
 <?php
 require_once '../includes/bootstrap.php'; // deine PDO-Verbindung
+require_once '../includes/absencetypes.php';
 
 // Fehleranzeige für Debug
 ini_set('display_errors', 1);
@@ -15,7 +16,7 @@ $erstellt_von = $_SESSION['user_id']; // Aktuell eingeloggter Benutzer
 // Initialisierung
 $eintraege = [];
 
-if (in_array($typ, ['Urlaub', 'Krank', 'Kind Krank'])) {
+if (in_array($typ, $ABSENCE_TYPES['period'], true)) {
     $von = $_POST['von_datum'];
     $bis = $_POST['bis_datum'];
 
@@ -36,7 +37,7 @@ if (in_array($typ, ['Urlaub', 'Krank', 'Kind Krank'])) {
             'bis' => null
         ];
     }
-} elseif (in_array($typ, ['Kommt später', 'Geht eher'])) {
+} elseif (in_array($typ, $ABSENCE_TYPES['time_point'], true)) {
     $datum = $_POST['zeitpunkt_datum'] ?? null;
     $zeit = $_POST['zeitpunkt'] ?? null;
 
@@ -57,7 +58,7 @@ if (in_array($typ, ['Urlaub', 'Krank', 'Kind Krank'])) {
         'von' => ($typ === 'Kommt später') ? $zeit : null,
         'bis' => ($typ === 'Geht eher') ? $zeit : null
     ];
-} elseif ($typ === 'Unterbrechung') {
+} elseif (in_array($typ, $ABSENCE_TYPES['time_range'], true)) {
     $datum = $_POST['tag_zeitspanne'];
     $von = $_POST['von_uhrzeit'];
     $bis = $_POST['bis_uhrzeit'];


### PR DESCRIPTION
## Summary
- add centralized absence type definitions with categories
- reuse central types in admin absence form and validation

## Testing
- `php -l includes/absencetypes.php`
- `php -l public/verwaltung_abwesenheit.php`
- `php -l public/verwaltung_abwesenheit_eintragen.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6aec7da8c832b88c271a77f68e0c7