### PR TITLE
style: align dashboard navigation lists

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -96,6 +96,10 @@ nav {
     display: flex;
     align-items: center;
     position: relative;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    justify-content: flex-end;
 }
 
 .nav-links a {
@@ -127,10 +131,13 @@ nav {
     background-color: #ffffff;
     color: var(--color-text);
     border-radius: 5px;
-    padding: 10px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
     z-index: 1000;
     min-width: 200px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    justify-content: flex-end;
 }
 
 .dropdown-menu a {


### PR DESCRIPTION
## Summary
- Remove bullets and align dashboard nav links to the right
- Strip bullets from dropdown menu entries

## Testing
- `npm test` (fails: Could not read package.json)
- `composer test` (fails: Command "test" is not defined)
- `phpunit` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6b7d1c664832b95593a62433127a8