### PR TITLE
Add Verwaltung navigation entry

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -67,6 +67,11 @@ $menuEntries = [
         'roles' => ['Admin', 'Mitarbeiter'],
     ],
     [
+        'label' => 'Verwaltung',
+        'url'   => 'verwaltung_abwesenheit.php',
+        'roles' => ['Admin', 'Mitarbeiter', 'Zentrale', 'Abrechnung'], // ggf. erweitern
+    ],
+    [
         'label' => 'Abrechnung',
         'roles' => ['Abrechnung'],
         'children' => [


### PR DESCRIPTION
## Summary
- include 'Verwaltung' menu entry in navigation with Admin/Mitarbeiter/Zentrale/Abrechnung roles

## Testing
- `php -l includes/navigation.php`
- `php -r "require 'includes/navigation.php'; renderMenu('Admin', '', 'top', 'verwaltung_abwesenheit.php');" | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b6b899af80832b8be1de52f9273b4b