### PR TITLE
Include Verwaltung in secondary roles array

### DIFF
--- a/public/benutzerverwaltung.php
+++ b/public/benutzerverwaltung.php
@@ -133,7 +133,7 @@ foreach ($spalten as $spalte) {
                     <td>
                         <select name="sekundar_rolle[<?= $row['BenutzerID'] ?>][]" multiple>
                             <?php
-                            $alleSekundarRollen = ['Abrechnung', 'Werkstatt', 'Admin', 'Zentrale'];
+                            $alleSekundarRollen = ['Abrechnung', 'Werkstatt', 'Admin', 'Zentrale', 'Verwaltung'];
                             $aktiveRollen = explode(',', $row['SekundarRolle']);
                             foreach ($alleSekundarRollen as $rolle) {
                                 $selected = in_array($rolle, $aktiveRollen) ? 'selected' : '';


### PR DESCRIPTION
## Summary
- allow selecting Verwaltung secondary role in user management

## Testing
- `php -l public/benutzerverwaltung.php`
- `php -r '$alleSekundarRollen=["Abrechnung","Werkstatt","Admin","Zentrale","Verwaltung"]; $row=["SekundarRolle"=>"Admin,Verwaltung"]; $aktiveRollen=explode(",",$row["SekundarRolle"]); foreach($alleSekundarRollen as $rolle){$selected=in_array($rolle,$aktiveRollen)?"selected":""; echo "<option value=\\"$rolle\\" $selected>$rolle</option>\\n";}'`
- `php -r '$post=["sekundar_rolle"=>[123=>["Admin","Verwaltung"]]]; $sekundarRolle=isset($post["sekundar_rolle"][123])?implode(",",$post["sekundar_rolle"][123]):""; echo $sekundarRolle;'`

------
https://chatgpt.com/codex/tasks/task_e_68b6bc9abff4832ba25512c7d45425d7