### PR TITLE
Check Verwaltung Sekundärrolle before updating absences

### DIFF
--- a/public/verwaltung_abwesenheit_status.php
+++ b/public/verwaltung_abwesenheit_status.php
@@ -5,6 +5,11 @@ if (!isLoggedIn()) {
     die("Nicht eingeloggt.");
 }
 
+$rollen = array_map('trim', explode(',', $sekundarRolle ?? ''));
+if (!in_array('Verwaltung', $rollen, true)) {
+    die("Keine Berechtigung.");
+}
+
 if (!isset($_POST['action'], $_POST['abwesenheit_ids']) || !in_array($_POST['action'], ['approve', 'reject'])) {
     die("Ungültige Anfrage.");
 }


### PR DESCRIPTION
## Summary
- Add secondary role check ensuring 'Verwaltung' role is present before changing absence statuses

## Testing
- `php -l public/verwaltung_abwesenheit_status.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6be6cf5d0832ba00d38c7b663da5d