### PR TITLE
Add Postfach navigation links

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -67,6 +67,11 @@ $menuEntries = [
         'roles' => ['Admin', 'Mitarbeiter'],
     ],
     [
+        'label' => 'Postfach',
+        'url' => 'messages/inbox.php',
+        'roles' => ['Admin', 'Mitarbeiter', 'Fahrer', 'Zentrale', 'Abrechnung'],
+    ],
+    [
         'label' => 'Verwaltung',
         'url'   => 'verwaltung_abwesenheit.php',
         'roles' => ['Admin', 'Mitarbeiter', 'Zentrale', 'Abrechnung'], // ggf. erweitern
@@ -166,6 +171,12 @@ $menuEntries = [
     [
         'label' => 'Umsatz',
         'url' => 'umsatz_erfassen.php',
+        'roles' => ['Fahrer'],
+        'context' => 'bottom',
+    ],
+    [
+        'label' => 'Postfach',
+        'url' => 'messages/inbox.php',
         'roles' => ['Fahrer'],
         'context' => 'bottom',
     ],

--- a/public/driver/driver-nav.php
+++ b/public/driver/driver-nav.php
@@ -10,6 +10,7 @@
     <ul>
         <li><a href="dashboard.php">Dashboard</a></li>
         <li><a href="umsatz_erfassen.php">Umsatz erfassen</a></li>
+        <li><a href="../messages/inbox.php">Postfach</a></li>
         <li><a href="../logout.php">Logout</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
## Summary
- Add Postfach to main navigation for all major roles
- Show Postfach link in driver navigation and bottom navigation

## Testing
- `php -l includes/navigation.php`
- `php -l public/driver/driver-nav.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6c11f362c832b9c4343ef323799ce