### PR TITLE
Fix bootstrap include path in inbox

### DIFF
--- a/public/messages/inbox.php
+++ b/public/messages/inbox.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../includes/bootstrap.php';
+require_once '../../includes/bootstrap.php';
 
 if (!isset($_SESSION['user_id'])) {
     header('Location: ../login.php');


### PR DESCRIPTION
## Summary
- Correct require path in messages inbox to reach project bootstrap from project root

## Testing
- `php -l public/messages/inbox.php`
- `php -r 'session_start(); $_SESSION["user_id"]=1; $_SERVER["SCRIPT_NAME"]="inbox.php"; $_SERVER["REQUEST_METHOD"]="GET"; require "inbox.php";'` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c9712ac4832b9425e2f301932436