### PR TITLE
Add navigation and standard layout to message inbox

### DIFF
--- a/public/messages/inbox.php
+++ b/public/messages/inbox.php
@@ -31,26 +31,27 @@ $messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <head>
     <meta charset="UTF-8">
     <title>Inbox</title>
-    <link rel="stylesheet" href="../css/index.css">
+    <link rel="stylesheet" href="../css/styles.css">
 </head>
 <body>
-<div class="wrapper">
-    <h1>Ungelesene Nachrichten</h1>
-    <?php if (empty($messages)): ?>
-        <p>Keine ungelesenen Nachrichten.</p>
-    <?php else: ?>
-        <?php foreach ($messages as $msg): ?>
-            <div class="message">
-                <h2><?= htmlspecialchars($msg['subject']) ?></h2>
-                <p><em>Von <?= htmlspecialchars($msg['sender_name']) ?> am <?= htmlspecialchars($msg['created_at']) ?></em></p>
-                <p><?= nl2br(htmlspecialchars($msg['body'])) ?></p>
-                <form method="post" style="display:inline;">
-                    <input type="hidden" name="mark_as_read" value="<?= $msg['id'] ?>">
-                    <button type="submit">Als gelesen markieren</button>
-                </form>
-            </div>
-        <?php endforeach; ?>
-    <?php endif; ?>
-</div>
+    <?php include '../nav.php'; ?>
+    <main>
+        <h1>Ungelesene Nachrichten</h1>
+        <?php if (empty($messages)): ?>
+            <p>Keine ungelesenen Nachrichten.</p>
+        <?php else: ?>
+            <?php foreach ($messages as $msg): ?>
+                <div class="message">
+                    <h2><?= htmlspecialchars($msg['subject']) ?></h2>
+                    <p><em>Von <?= htmlspecialchars($msg['sender_name']) ?> am <?= htmlspecialchars($msg['created_at']) ?></em></p>
+                    <p><?= nl2br(htmlspecialchars($msg['body'])) ?></p>
+                    <form method="post" style="display:inline;">
+                        <input type="hidden" name="mark_as_read" value="<?= $msg['id'] ?>">
+                        <button type="submit">Als gelesen markieren</button>
+                    </form>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add navigation bar inclusion to inbox page for consistent navigation.
- Switch inbox page stylesheet to global styles and wrap content in `<main>` to match site layout.

## Testing
- `php -l public/messages/inbox.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6caeb3118832b9452fd52d30761ec