### PR TITLE
Add date and time range support for admin absences

### DIFF
--- a/migrations/2024090203_alter_verwaltung_abwesenheit.sql
+++ b/migrations/2024090203_alter_verwaltung_abwesenheit.sql
@@ -1,0 +1,7 @@
+ALTER TABLE verwaltung_abwesenheit
+    ADD COLUMN startdatum DATE NULL AFTER datum,
+    ADD COLUMN enddatum DATE NULL AFTER startdatum,
+    ADD COLUMN startzeit TIME NULL AFTER enddatum,
+    ADD COLUMN endzeit TIME NULL AFTER startzeit,
+    DROP COLUMN von,
+    DROP COLUMN bis;


### PR DESCRIPTION
## Summary
- extend `verwaltung_abwesenheit` table with date range and time range columns
- capture and store absences with start/end dates or times via new form and backend logic
- render multi-day and single-day absences correctly in views

## Testing
- `php -l public/verwaltung_abwesenheit.php`
- `php -l public/verwaltung_abwesenheit_eintragen.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6cedf5d0c832b9558a03e7d8849cf