### PR TITLE
Use unified session role for access control

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -8,11 +8,11 @@ function isLoggedIn() {
 }
 
 function isDriver() {
-    return isLoggedIn() && $_SESSION['user_type'] === 'Fahrer';
+    return isLoggedIn() && ($_SESSION['user_role'] ?? '') === 'fahrer';
 }
 
 function isAdmin() {
-    return isLoggedIn() && $_SESSION['user_type'] === 'Benutzer';
+    return isLoggedIn() && ($_SESSION['user_role'] ?? '') === 'admin';
 }
 
 function redirectToDashboard() {

--- a/includes/secure.php
+++ b/includes/secure.php
@@ -7,7 +7,7 @@ if (!isset($_SESSION['user_role'])) {
 if ($_SESSION['user_role'] === 'fahrer') {
     header("Location: ../driver/dashboard.php");
     exit();
-} elseif ($_SESSION['user_role'] === 'benutzer') {
+} elseif ($_SESSION['user_role'] === 'admin') {
     header("Location: dashboard.php");
     exit();
 } else {

--- a/public/login.php
+++ b/public/login.php
@@ -12,8 +12,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
     if ($user && password_verify($password, $user['Passwort'])) {
-        // Benutzer erfolgreich eingeloggt
-        $_SESSION['user_role'] = 'benutzer';
+        // Admin erfolgreich eingeloggt
+        $_SESSION['user_role'] = 'admin';
         $_SESSION['user_id'] = $user['BenutzerID'];
         header("Location: dashboard.php");
         exit();


### PR DESCRIPTION
## Summary
- Switch `isDriver` and `isAdmin` to check the `user_role` session value
- Store `admin` role on user login and `fahrer` for drivers
- Redirect based on `user_role` in secure page

## Testing
- `php -l includes/auth.php`
- `php -l public/login.php`
- `php -l includes/secure.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d1feb4f4832bb6689de825f45266