### PR TITLE
feat: unify head template with bootstrap

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1,0 +1,6 @@
+/* Minimal custom styles extending Bootstrap */
+.weekend { background-color: #f8d7da; color: #721c24; }
+.early-shift { background-color: #d4edda; color: #155724; }
+.mid-shift { background-color: #fff3cd; color: #856404; }
+.late-shift { background-color: #d1ecf1; color: #0c5460; }
+.night-shift { background-color: #d6d8db; color: #343a40; }

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -84,58 +84,10 @@ foreach ($dienstplan as $entry) {
     $dienstplanMap[$entry['mitarbeiter_id']][$entry['datum']] = $entry['schicht_name'];
 }
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dashboard</title>
-    <link rel="stylesheet" href="css/dashboard.css">
-    <style>
-        .dashboard-table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-top: 20px;
-            font-size: 14px;
-        }
-
-        .dashboard-table th, .dashboard-table td {
-            border: 1px solid #ddd;
-            padding: 8px;
-            text-align: center;
-        }
-
-        .dashboard-table th {
-            background-color: #f4f4f4;
-            font-weight: bold;
-        }
-
-        .dashboard-table .weekend {
-            background-color: #f8d7da;
-            color: #721c24;
-        }
-
-        .dashboard-table .early-shift {
-            background-color: #d4edda;
-            color: #155724;
-        }
-
-        .dashboard-table .mid-shift {
-            background-color: #fff3cd;
-            color: #856404;
-        }
-
-        .dashboard-table .late-shift {
-            background-color: #d1ecf1;
-            color: #0c5460;
-        }
-
-        .dashboard-table .night-shift {
-            background-color: #d6d8db;
-            color: #343a40;
-        }
-    </style>
-</head>
+<?php
+$title = 'Dashboard';
+include 'head.php';
+?>
 <body>
     <?php include 'nav.php'; ?>
 
@@ -440,7 +392,7 @@ foreach ($dienstplan as $entry) {
 
             <section id="dienstplan-zentrale" class="widget">
                 <h2>Schichtplan Zentrale</h2>
-                <table class="dashboard-table">
+                <table class="table">
                     <thead>
                         <tr>
                             <th>Mitarbeiter</th>

--- a/public/head.php
+++ b/public/head.php
@@ -1,3 +1,14 @@
 <?php
 require_once '../includes/bootstrap.php';
 ?>
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($title ?? 'DRIVE'); ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QY6pDz0YjU+vWXTjhBMWrMUR3pvN8I2c2MvmXrKE+g6uSPRqCMgfHdCqkfNNPJwN" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/custom.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-w74AqDTFDzJr3TOScKq3Y0CA8DmFumiQJ5AZt0pOEtp5uWZL0E+nobVHTp6fmx4d" crossorigin="anonymous"></script>
+</head>

--- a/public/message_permissions.php
+++ b/public/message_permissions.php
@@ -41,20 +41,16 @@ $permissions = [];
 while ($row = $permStmt->fetch(PDO::FETCH_ASSOC)) {
     $permissions[$row['driver_id']][] = $row['recipient_id'];
 }
+
+$title = 'Nachrichtenberechtigungen';
+include 'head.php';
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Nachrichtenberechtigungen</title>
-    <link rel="stylesheet" href="css/index.css">
-</head>
 <body>
 <?php include 'nav.php'; ?>
-<div class="wrapper">
+<div class="container my-4">
     <h1>Nachrichtenberechtigungen</h1>
     <form method="post">
-        <table>
+        <table class="table">
             <thead>
                 <tr>
                     <th>Fahrer</th>
@@ -66,7 +62,7 @@ while ($row = $permStmt->fetch(PDO::FETCH_ASSOC)) {
                 <tr>
                     <td><?= htmlspecialchars($driver['name']) ?></td>
                     <td>
-                        <select name="recipients[<?= $driver['FahrerID'] ?>][]" multiple size="5">
+                        <select name="recipients[<?= $driver['FahrerID'] ?>][]" multiple size="5" class="form-select">
                             <?php
                             $selected = $permissions[$driver['FahrerID']] ?? [];
                             foreach ($users as $user):
@@ -80,7 +76,7 @@ while ($row = $permStmt->fetch(PDO::FETCH_ASSOC)) {
             <?php endforeach; ?>
             </tbody>
         </table>
-        <button type="submit">Speichern</button>
+        <button type="submit" class="btn btn-primary">Speichern</button>
     </form>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- centralize Bootstrap assets via shared head.php
- apply Bootstrap styles to dashboard and message permissions
- add minimal custom CSS for shift highlighting

## Testing
- `php -l public/head.php`
- `php -l public/message_permissions.php`
- `php -l public/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6d3de974c832b8f98125ffc747098