### PR TITLE
Style dashboard sections as Bootstrap cards

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -60,3 +60,12 @@
         display: flex;
     }
 }
+
+/* Card enhancements */
+.card {
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+
+.card-body {
+    padding: 1rem;
+}

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -140,28 +140,29 @@ include 'head.php';
 						$firmenGruppiert[$anzeigeName][] = $eintrag;
 					}
 
-					if (!empty($firmenGruppiert)) {
-						foreach ($firmenGruppiert as $firma => $fahrerListe) {
-							echo "<section class='widget'>";
-							echo "<h2>" . htmlspecialchars($firma) . "</h2>";
-							echo "<ul>";
-							foreach ($fahrerListe as $fahrer) {
-								echo "<li><strong>" . htmlspecialchars($fahrer['fahrer_vorname']) . " " . htmlspecialchars($fahrer['fahrer_nachname']) . "</strong>";
-								echo " – Kennzeichen: " . htmlspecialchars($fahrer['kennzeichen']);
-								echo "</li>";
-							}
-							echo "</ul>";
-							echo "</section>";
-						}
-					} else {
-						echo "<section class='widget'><p>Aktuell sind keine Fahrer angemeldet.</p></section>";
-					}
-				} catch (PDOException $e) {
-					echo "<section class='widget'><p>Fehler bei der Fahrerabfrage: " . htmlspecialchars($e->getMessage()) . "</p></section>";
-				}
-				?>
+                                        if (!empty($firmenGruppiert)) {
+                                                foreach ($firmenGruppiert as $firma => $fahrerListe) {
+                                                        echo "<section class='widget card mb-3'><div class='card-body'>";
+                                                        echo "<h2>" . htmlspecialchars($firma) . "</h2>";
+                                                        echo "<ul>";
+                                                        foreach ($fahrerListe as $fahrer) {
+                                                                echo "<li><strong>" . htmlspecialchars($fahrer['fahrer_vorname']) . " " . htmlspecialchars($fahrer['fahrer_nachname']) . "</strong>";
+                                                                echo " – Kennzeichen: " . htmlspecialchars($fahrer['kennzeichen']);
+                                                                echo "</li>";
+                                                        }
+                                                        echo "</ul>";
+                                                        echo "</div></section>";
+                                                }
+                                        } else {
+                                                echo "<section class='widget card mb-3'><div class='card-body'><p>Aktuell sind keine Fahrer angemeldet.</p></div></section>";
+                                        }
+                                } catch (PDOException $e) {
+                                        echo "<section class='widget card mb-3'><div class='card-body'><p>Fehler bei der Fahrerabfrage: " . htmlspecialchars($e->getMessage()) . "</p></div></section>";
+                                }
+                                ?>
 
-            <section id="tageshighlights" class="widget">
+            <section id="tageshighlights" class="widget card mb-3">
+                <div class="card-body">
                 <h2>Tageshighlights</h2>
                 <div id="birthdays">
                     <h3>Geburtstage</h3>
@@ -225,9 +226,11 @@ include 'head.php';
                         ?>
                     </ul>
                 </div>
+                </div>
             </section>
 
-            <section id="krank-urlaub" class="widget">
+            <section id="krank-urlaub" class="widget card mb-3">
+                <div class="card-body">
                 <h2>Krank/Urlaub</h2>
                 <div id="abteilungen">
                     <div class='department'>
@@ -286,9 +289,11 @@ include 'head.php';
                         </ul>
                     </div>
                 </div>
+                </div>
             </section>
 
-            <section id="tuev" class="widget">
+            <section id="tuev" class="widget card mb-3">
+                <div class="card-body">
                 <h2>Fällige TÜV</h2>
                 <ul>
                     <?php
@@ -309,9 +314,11 @@ include 'head.php';
                     }
                     ?>
                 </ul>
+                </div>
             </section>
 
-            <section id="eichung" class="widget">
+            <section id="eichung" class="widget card mb-3">
+                <div class="card-body">
                 <h2>Wartungstermine</h2>
                 <ul>
                     <?php
@@ -333,11 +340,13 @@ include 'head.php';
                     }
                     ?>
                 </ul>
+                </div>
             </section>
 
-            <section id="pschein" class="widget">
-				<h2>Bald ablaufende P-Scheine</h2>
-				<ul>
+            <section id="pschein" class="widget card mb-3">
+                                <div class="card-body">
+                                <h2>Bald ablaufende P-Scheine</h2>
+                                <ul>
 					<?php
 					try {
 						$stmt = $pdo->prepare("SELECT CONCAT(Vorname, ' ', Nachname) AS Name, DATE_FORMAT(PScheinGueltigkeit, '%d.%m.%Y') AS PScheinGueltigkeit FROM Fahrer WHERE PScheinGueltigkeit BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 3 MONTH) ORDER BY PScheinGueltigkeit ASC");
@@ -355,12 +364,14 @@ include 'head.php';
 						echo "<li>Fehler bei der Abfrage: " . htmlspecialchars($e->getMessage()) . "</li>";
 					}
 					?>
-				</ul>
-			</section>
+                                </ul>
+                                </div>
+                        </section>
 			
-			<section id="zentraler-dienstplan" class="widget">
-				<h2>Zentraler Dienstplan</h2>
-				<div id="heutige-schicht">
+                        <section id="zentraler-dienstplan" class="widget card mb-3">
+                                <div class="card-body">
+                                <h2>Zentraler Dienstplan</h2>
+                                <div id="heutige-schicht">
 					<h3>Heutige Schicht</h3>
 					<ul>
 						<?php
@@ -387,10 +398,12 @@ include 'head.php';
 						}
 						?>
 					</ul>
-				</div>
-			</section>
+                                </div>
+                                </div>
+                        </section>
 
-            <section id="dienstplan-zentrale" class="widget">
+            <section id="dienstplan-zentrale" class="widget card mb-3">
+                <div class="card-body">
                 <h2>Schichtplan Zentrale</h2>
                 <table class="table">
                     <thead>
@@ -446,6 +459,7 @@ include 'head.php';
                         <?php endif; ?>
                     </tbody>
                 </table>
+                </div>
             </section>
 
         </main>

--- a/public/driver/dashboard.php
+++ b/public/driver/dashboard.php
@@ -454,7 +454,8 @@ $fahrerHinweis = $stmtHinweis->fetch(PDO::FETCH_ASSOC);
 		
         <p>Hier findest du eine Übersicht deiner Umsätze.</p>
         
-        <section>
+        <section class="card mb-3">
+            <div class="card-body">
             <h2>Umsatzübersicht</h2>
             <form method="GET" action="dashboard.php">
                 <label for="zeitraum">Zeitraum:</label>
@@ -526,7 +527,8 @@ $fahrerHinweis = $stmtHinweis->fetch(PDO::FETCH_ASSOC);
                     <?php endif; ?>
                 </tbody>
             </table>
-			<a href="statistics.php">Statistik</a>
+                        <a href="statistics.php">Statistik</a>
+            </div>
         </section>
     </main>
 	<script>


### PR DESCRIPTION
## Summary
- Wrap dashboard widgets in Bootstrap `card` components and add consistent `card-body` containers.
- Apply the same card layout to the driver dashboard overview section.
- Introduce custom CSS for card shadows and padding.

## Testing
- `php -l public/dashboard.php`
- `php -l public/driver/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6dc0421b4832bafff0fefde220193