### PR TITLE
feat: add base theme variables and cache busting

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1,3 +1,21 @@
+:root {
+    --primary-color: var(--bs-primary);
+    --secondary-color: var(--bs-secondary);
+    --font-family-base: var(--bs-body-font-family);
+    --body-bg-color: var(--bs-body-bg);
+}
+
+body {
+    font-family: var(--font-family-base);
+    background-color: var(--body-bg-color);
+    font-size: 1rem;
+}
+
+.container {
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
 /* Minimal custom styles extending Bootstrap */
 .weekend { background-color: #f8d7da; color: #721c24; }
 .early-shift { background-color: #d4edda; color: #155724; }

--- a/public/head.php
+++ b/public/head.php
@@ -9,6 +9,6 @@ require_once '../includes/bootstrap.php';
     <title><?= htmlspecialchars($title ?? 'DRIVE'); ?></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QY6pDz0YjU+vWXTjhBMWrMUR3pvN8I2c2MvmXrKE+g6uSPRqCMgfHdCqkfNNPJwN" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
-    <link rel="stylesheet" href="css/custom.css">
+    <link rel="stylesheet" href="css/custom.css?v=<?= filemtime(__DIR__ . '/css/custom.css'); ?>">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-w74AqDTFDzJr3TOScKq3Y0CA8DmFumiQJ5AZt0pOEtp5uWZL0E+nobVHTp6fmx4d" crossorigin="anonymous"></script>
 </head>


### PR DESCRIPTION
## Summary
- define custom CSS variables and base layout rules to align with Bootstrap theme
- load custom stylesheet with cache-busting query parameter

## Testing
- `php -l public/head.php`
- `npx stylelint public/css/custom.css` *(fails: 403 Forbidden fetching stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dcfd05a8832bb0ecb0f7b8d6eee3