### PR TITLE
Add conversation and message history features

### DIFF
--- a/app/Controllers/MessageController.php
+++ b/app/Controllers/MessageController.php
@@ -5,6 +5,32 @@ use App\Models\Message;
 
 class MessageController
 {
+    public function index(): void
+    {
+        session_start();
+        if (!isset($_SESSION['user_id'])) {
+            header('Location: /login.php');
+            exit;
+        }
+
+        $userId = (int) $_SESSION['user_id'];
+        $conversations = Message::getConversationsByUser($userId);
+        include __DIR__ . '/../Views/messages/index.php';
+    }
+
+    public function show(int $otherId): void
+    {
+        session_start();
+        if (!isset($_SESSION['user_id'])) {
+            header('Location: /login.php');
+            exit;
+        }
+
+        $userId = (int) $_SESSION['user_id'];
+        $messages = Message::getMessagesBetween($userId, $otherId);
+        include __DIR__ . '/../Views/messages/show.php';
+    }
+
     public function inbox(): void
     {
         session_start();

--- a/app/Views/messages/index.php
+++ b/app/Views/messages/index.php
@@ -1,0 +1,32 @@
+<?php
+// expects $conversations
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Nachrichten</title>
+    <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body>
+    <?php include __DIR__ . '/../../../public/nav.php'; ?>
+    <main>
+        <h1>Konversationen</h1>
+        <?php if (empty($conversations)): ?>
+            <p>Keine Nachrichten.</p>
+        <?php else: ?>
+            <ul>
+            <?php foreach ($conversations as $conv): ?>
+                <li>
+                    <a href="/messages/<?= $conv['other_id'] ?>">
+                        <?= htmlspecialchars($conv['other_name']) ?>
+                    </a>
+                    <p><em><?= htmlspecialchars($conv['created_at']) ?></em></p>
+                    <p><?= htmlspecialchars($conv['subject']) ?></p>
+                </li>
+            <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </main>
+</body>
+</html>

--- a/app/Views/messages/show.php
+++ b/app/Views/messages/show.php
@@ -1,0 +1,28 @@
+<?php
+// expects $messages
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Nachrichtenverlauf</title>
+    <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body>
+    <?php include __DIR__ . '/../../../public/nav.php'; ?>
+    <main>
+        <h1>Verlauf</h1>
+        <?php if (empty($messages)): ?>
+            <p>Keine Nachrichten vorhanden.</p>
+        <?php else: ?>
+            <?php foreach ($messages as $msg): ?>
+                <div class="message">
+                    <p><strong><?= htmlspecialchars($msg['sender_name']) ?>:</strong> <?= nl2br(htmlspecialchars($msg['body'])) ?></p>
+                    <p><em><?= htmlspecialchars($msg['created_at']) ?></em></p>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        <p><a href="/messages">Zurück zur Übersicht</a></p>
+    </main>
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -17,20 +17,17 @@ spl_autoload_register(function (string $class): void {
 
 $uri = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
 
-switch ($uri) {
-    case '':
-    case 'index.php':
-    case 'login':
-        require __DIR__ . '/login.php';
-        break;
-    case 'messages':
-    case 'messages/inbox':
-        (new App\Controllers\MessageController())->inbox();
-        break;
-    case 'messages/mark-as-read':
-        (new App\Controllers\MessageController())->markAsRead();
-        break;
-    default:
-        http_response_code(404);
-        echo 'Seite nicht gefunden';
+if ($uri === '' || $uri === 'index.php' || $uri === 'login') {
+    require __DIR__ . '/login.php';
+} elseif ($uri === 'messages') {
+    (new App\Controllers\MessageController())->index();
+} elseif (preg_match('#^messages/([0-9]+)$#', $uri, $matches)) {
+    (new App\Controllers\MessageController())->show((int)$matches[1]);
+} elseif ($uri === 'messages/mark-as-read') {
+    (new App\Controllers\MessageController())->markAsRead();
+} elseif ($uri === 'messages/inbox') {
+    (new App\Controllers\MessageController())->inbox();
+} else {
+    http_response_code(404);
+    echo 'Seite nicht gefunden';
 }


### PR DESCRIPTION
## Summary
- add Message model helpers for conversation overview and message history
- extend MessageController with conversation list and show methods
- expose new message routes and views

## Testing
- `php -l app/Models/Message.php`
- `php -l app/Controllers/MessageController.php`
- `php -l app/Views/messages/index.php`
- `php -l app/Views/messages/show.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6dceeb094832ba1bc2d959dd61b7f