### PR TITLE
Add flexbox messages view and styles

### DIFF
--- a/app/Views/messages/index.php
+++ b/app/Views/messages/index.php
@@ -1,5 +1,13 @@
 <?php
-// expects $conversations
+use App\Models\Message;
+
+// $conversations expected from controller
+
+$selectedUserId = isset($_GET['user']) ? (int) $_GET['user'] : null;
+$messages = [];
+if ($selectedUserId && isset($_SESSION['user_id'])) {
+    $messages = Message::getMessagesBetween((int) $_SESSION['user_id'], $selectedUserId);
+}
 ?>
 <!DOCTYPE html>
 <html lang="de">
@@ -7,26 +15,46 @@
     <meta charset="UTF-8">
     <title>Nachrichten</title>
     <link rel="stylesheet" href="/css/styles.css">
+    <link rel="stylesheet" href="/css/messages.css">
 </head>
 <body>
     <?php include __DIR__ . '/../../../public/nav.php'; ?>
-    <main>
-        <h1>Konversationen</h1>
-        <?php if (empty($conversations)): ?>
-            <p>Keine Nachrichten.</p>
-        <?php else: ?>
-            <ul>
-            <?php foreach ($conversations as $conv): ?>
-                <li>
-                    <a href="/messages/<?= $conv['other_id'] ?>">
-                        <?= htmlspecialchars($conv['other_name']) ?>
-                    </a>
-                    <p><em><?= htmlspecialchars($conv['created_at']) ?></em></p>
-                    <p><?= htmlspecialchars($conv['subject']) ?></p>
-                </li>
-            <?php endforeach; ?>
-            </ul>
-        <?php endif; ?>
+    <main class="messages-container">
+        <aside class="conversations">
+            <h2>Gesprächspartner</h2>
+            <?php if (empty($conversations)): ?>
+                <p>Keine Nachrichten.</p>
+            <?php else: ?>
+                <ul>
+                <?php foreach ($conversations as $conv): ?>
+                    <li>
+                        <a href="/messages?user=<?= $conv['other_id'] ?>">
+                            <?= htmlspecialchars($conv['other_name']) ?>
+                        </a>
+                    </li>
+                <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </aside>
+
+        <section class="conversation">
+            <?php if ($selectedUserId && !empty($messages)): ?>
+                <h2><?= htmlspecialchars($messages[0]['subject']) ?></h2>
+                <div class="messages">
+                    <?php foreach ($messages as $msg): ?>
+                        <div class="message">
+                            <p><strong><?= htmlspecialchars($msg['sender_name']) ?>:</strong> <?= nl2br(htmlspecialchars($msg['body'])) ?></p>
+                            <p class="timestamp"><em><?= htmlspecialchars($msg['created_at']) ?></em></p>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php elseif ($selectedUserId): ?>
+                <p>Keine Nachrichten vorhanden.</p>
+            <?php else: ?>
+                <p>Wähle einen Gesprächspartner aus.</p>
+            <?php endif; ?>
+        </section>
     </main>
 </body>
 </html>
+

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -1,0 +1,38 @@
+.messages-container {
+    display: flex;
+    height: 80vh;
+}
+
+.messages-container .conversations {
+    flex: 0 0 30%;
+    max-width: 300px;
+    border-right: 1px solid #ccc;
+    overflow-y: auto;
+    padding: 1rem;
+}
+
+.messages-container .conversations ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.messages-container .conversations li + li {
+    margin-top: 0.5rem;
+}
+
+.messages-container .conversation {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+}
+
+.messages-container .message {
+    margin-bottom: 1rem;
+}
+
+.messages-container .timestamp {
+    font-size: 0.8rem;
+    color: #666;
+}
+


### PR DESCRIPTION
## Summary
- Display conversation partners and message history in a two-column flex layout
- Show message subject, timestamp and body using getMessagesBetween
- Add dedicated CSS for scrolling columns and layout

## Testing
- `php -l app/Views/messages/index.php`
- `npx stylelint public/css/messages.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6def96a78832b99074b1b1965a652