### PR TITLE
Restrict driver message recipients

### DIFF
--- a/public/api/recipients.php
+++ b/public/api/recipients.php
@@ -1,0 +1,29 @@
+<?php
+require_once '../../includes/bootstrap.php';
+
+header('Content-Type: application/json');
+
+if (!isLoggedIn()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Nicht angemeldet']);
+    exit;
+}
+
+$userId = (int) $_SESSION['user_id'];
+
+if (isDriver()) {
+    $stmt = $pdo->prepare(
+        'SELECT b.BenutzerID AS id, b.Name
+         FROM message_permissions mp
+         JOIN Benutzer b ON b.BenutzerID = mp.recipient_id
+         WHERE mp.driver_id = ?
+         ORDER BY b.Name'
+    );
+    $stmt->execute([$userId]);
+    $recipients = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} else {
+    $stmt = $pdo->query('SELECT FahrerID AS id, CONCAT(Vorname, " ", Nachname) AS Name FROM Fahrer ORDER BY Nachname, Vorname');
+    $recipients = $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+echo json_encode($recipients);

--- a/public/messages/store.php
+++ b/public/messages/store.php
@@ -1,0 +1,36 @@
+<?php
+require_once '../../includes/bootstrap.php';
+
+header('Content-Type: application/json');
+
+if (!isLoggedIn()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Nicht angemeldet']);
+    exit;
+}
+
+$senderId = (int) $_SESSION['user_id'];
+$recipientId = (int) ($_POST['recipient_id'] ?? 0);
+$subject = trim($_POST['subject'] ?? '');
+$body = trim($_POST['body'] ?? '');
+
+if ($recipientId === 0 || $subject === '' || $body === '') {
+    http_response_code(422);
+    echo json_encode(['error' => 'Ungültige Eingabe']);
+    exit;
+}
+
+if (isDriver()) {
+    $check = $pdo->prepare('SELECT 1 FROM message_permissions WHERE driver_id = ? AND recipient_id = ?');
+    $check->execute([$senderId, $recipientId]);
+    if (!$check->fetchColumn()) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Empfänger nicht erlaubt']);
+        exit;
+    }
+}
+
+$stmt = $pdo->prepare('INSERT INTO messages (sender_id, recipient_id, subject, body) VALUES (?, ?, ?, ?)');
+$stmt->execute([$senderId, $recipientId, $subject, $body]);
+
+echo json_encode(['status' => 'ok']);


### PR DESCRIPTION
## Summary
- Add API endpoint to return allowed message recipients depending on user role
- Add message submission endpoint validating recipient permissions

## Testing
- `php -l public/api/recipients.php`
- `php -l public/messages/store.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6e01d0308832b8236eace12afde5d