### PR TITLE
feat: centralize layout for head and navigation

### DIFF
--- a/app/Views/messages/index.php
+++ b/app/Views/messages/index.php
@@ -9,17 +9,12 @@ if ($selectedUserId && isset($_SESSION['user_id'])) {
     $messages = Message::getMessagesBetween((int) $_SESSION['user_id'], $selectedUserId);
 }
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Nachrichten</title>
-    <link rel="stylesheet" href="/css/custom.css">
-    <link rel="stylesheet" href="/css/messages.css">
-</head>
-<body>
-    <?php include __DIR__ . '/../../../public/nav.php'; ?>
-    <main class="messages-container">
+<?php
+$title = 'Nachrichten';
+include __DIR__ . '/../../../includes/layout.php';
+?>
+<link rel="stylesheet" href="/css/messages.css">
+<main class="messages-container">
         <aside class="conversations">
             <h2>Gesprächspartner</h2>
             <?php if (empty($conversations)): ?>

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -1,0 +1,6 @@
+<?php
+// Central layout to include common head and navigation
+include __DIR__ . '/../public/head.php';
+?>
+<body>
+<?php include __DIR__ . '/../public/nav.php'; ?>

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -86,36 +86,8 @@ foreach ($dienstplan as $entry) {
 ?>
 <?php
 $title = 'Dashboard';
-include 'head.php';
+include '../includes/layout.php';
 ?>
-<body>
-    <?php
-        require_once '../includes/navigation.php';
-        $currentPage = basename($_SERVER['PHP_SELF']);
-
-        $secondaryRoles = $sekundarRolle ?? '';
-        if (is_string($secondaryRoles)) {
-            $secondary = array_filter(array_map('trim', explode(',', $secondaryRoles)));
-        } elseif (is_array($secondaryRoles)) {
-            $secondary = $secondaryRoles;
-        } else {
-            $secondary = [];
-        }
-
-        $userRoles = [
-            'primary' => $_SESSION['rolle'] ?? '',
-            'secondary' => $secondary,
-        ];
-
-        $items = array_filter($menuEntries, static function ($item) {
-            return ($item['context'] ?? 'top') === 'top';
-        });
-
-        echo '<nav><div class="burger-menu"><i class="bi bi-list"></i></div>' .
-            buildMenu($items, $userRoles, $currentPage) .
-            '</nav>';
-    ?>
-
     <div class="container">
         <header>
 			<h1 id="greeting"></h1>

--- a/public/message_permissions.php
+++ b/public/message_permissions.php
@@ -43,10 +43,8 @@ while ($row = $permStmt->fetch(PDO::FETCH_ASSOC)) {
 }
 
 $title = 'Nachrichtenberechtigungen';
-include 'head.php';
+include '../includes/layout.php';
 ?>
-<body>
-<?php include 'nav.php'; ?>
 <div class="container my-4">
     <h1>Nachrichtenberechtigungen</h1>
     <form method="post">


### PR DESCRIPTION
## Summary
- Add reusable `includes/layout.php` to pull in shared head and navigation fragments
- Switch dashboard, message permissions, and messages view to use the new layout

## Testing
- `php -l includes/layout.php`
- `php -l public/message_permissions.php`
- `php -l public/dashboard.php`
- `php -l app/Views/messages/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6f044cb5c832b9dc3d10eee07260a