### PR TITLE
fix: correct inbox navigation link

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -80,7 +80,7 @@ $menuEntries = [
     ],
     [
         'label' => 'Postfach',
-        'url' => 'messages/inbox.php',
+        'url' => 'messages/inbox',
         'roles' => ['Admin', 'Mitarbeiter', 'Fahrer', 'Zentrale', 'Abrechnung'],
         'icon' => 'bi-envelope',
     ],


### PR DESCRIPTION
## Summary
- update navigation menu so inbox link uses router path

## Testing
- `php -l includes/navigation.php`
- `php -S 127.0.0.1:8000 -t public public/index.php >/tmp/php-server.log 2>&1 &`
- `curl -i 127.0.0.1:8000/messages/inbox`


------
https://chatgpt.com/codex/tasks/task_e_68b6ffad65ec832bb54e6e9edda46cb3