### PR TITLE
Use shared head include for message inbox view

### DIFF
--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -1,13 +1,8 @@
 <?php
 // expects $messages
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Inbox</title>
-    <link rel="stylesheet" href="/css/custom.css">
-</head>
+<?php include __DIR__ . '/../../../public/head.php'; ?>
+<link rel="stylesheet" href="/css/messages.css">
 <body>
     <?php include __DIR__ . '/../../../public/nav.php'; ?>
     <main>


### PR DESCRIPTION
## Summary
- Use shared `head.php` include in messages inbox view
- Add page-specific stylesheet and include navigation after body tag

## Testing
- `php -l app/Views/messages/inbox.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7cdc9aba4832b887ae60ee6c607c0