### PR TITLE
Use layout for login and allow optional navigation

### DIFF
--- a/includes/layout.php
+++ b/includes/layout.php
@@ -1,6 +1,9 @@
 <?php
 // Central layout to include common head and navigation
 include __DIR__ . '/../public/head.php';
+
+// Allow pages to disable the navigation bar by setting $showNav = false
+$showNav = $showNav ?? true;
 ?>
 <body>
-<?php include __DIR__ . '/../public/nav.php'; ?>
+<?php if ($showNav) { include __DIR__ . '/../public/nav.php'; } ?>

--- a/public/login.php
+++ b/public/login.php
@@ -35,17 +35,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Wenn weder Benutzer noch Fahrer erfolgreich waren
     $error = 'Ungültige Anmeldedaten!';
 }
+
+$title = 'Login';
+$showNav = false;
+include __DIR__ . '/../includes/layout.php';
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
     <link rel="stylesheet" href="css/index.css">
-</head>
-<body>
     <div class="wrapper">
         <header>
             <img src="images/4884-logo.png" alt="Ihr Leipzig Taxi 4884" class="logo">


### PR DESCRIPTION
## Summary
- Allow hiding the navigation bar via `$showNav` in the shared layout
- Switch the login page to use the common layout and disable navigation

## Testing
- `php -l includes/layout.php`
- `php -l public/login.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7d37350b0832b81d34bf2216d401b