### PR TITLE
Use layout for login and allow optional navigation

### DIFF
--- a/includes/layout.php
+++ b/includes/layout.php
@@ -1,6 +1,9 @@
 <?php
 // Central layout to include common head and navigation
 include __DIR__ . '/../public/head.php';
+
+// Allow pages to disable the navigation bar by setting $showNav = false
+$showNav = $showNav ?? true;
 ?>
 <body>
-<?php include __DIR__ . '/../public/nav.php'; ?>
+<?php if ($showNav) { include __DIR__ . '/../public/nav.php'; } ?>

--- a/public/abwesenheit_fahrer.php
+++ b/public/abwesenheit_fahrer.php
@@ -65,13 +65,10 @@ setlocale(LC_TIME, 'de_DE.UTF-8');
 $formatter = new IntlDateFormatter('de_DE', IntlDateFormatter::LONG, IntlDateFormatter::NONE);
 $formatter->setPattern('MMMM yyyy');
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Fahrer Abwesenheiten | DRIVE</title>
-  <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Fahrer Abwesenheiten';
+include __DIR__ . '/../includes/layout.php';
+?>
   <script src="js/modal.js"></script>
   <style>
     /* Basisstil für Kalenderzellen */
@@ -81,13 +78,11 @@ $formatter->setPattern('MMMM yyyy');
 	  border: 1px solid #ddd;
 	  transition: transform 0.2s, box-shadow 0.2s;
 	}
-
 	/* Hover-Effekt für Zellen */
 	.dashboard-table td:hover {
 	  transform: scale(1.05);
 	  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
 	}
-
 	/* Farben und Stil für Krankheitsfälle */
 	.absent-krank, .absent-kind-krank {
 	  background: linear-gradient(135deg, #0044cc, #3366ff); /* dunkler bis heller Blauverlauf */
@@ -96,7 +91,6 @@ $formatter->setPattern('MMMM yyyy');
 	  font-weight: bold;
 	  box-shadow: inset 0 0 5px rgba(0,0,0,0.3);
 	}
-
 	/* Farben und Stil für Urlaubsfälle */
 	.absent-vacation-beantragt {
 	  background: linear-gradient(135deg, #ffcc00, #ffff66); /* gelber Verlauf */
@@ -105,7 +99,6 @@ $formatter->setPattern('MMMM yyyy');
 	  font-weight: bold;
 	  box-shadow: inset 0 0 5px rgba(0,0,0,0.3);
 	}
-
 	.absent-vacation-genehmigt {
 	  background: linear-gradient(135deg, #008000, #66cc66); /* grüner Verlauf */
 	  color: white;
@@ -113,7 +106,6 @@ $formatter->setPattern('MMMM yyyy');
 	  font-weight: bold;
 	  box-shadow: inset 0 0 5px rgba(0,0,0,0.3);
 	}
-
 	.absent-vacation-abgelehnt {
 	  background: linear-gradient(135deg, #cc0000, #ff3333); /* roter Verlauf */
 	  color: white;
@@ -121,7 +113,6 @@ $formatter->setPattern('MMMM yyyy');
 	  font-weight: bold;
 	  box-shadow: inset 0 0 5px rgba(0,0,0,0.3);
 	}
-
 	.absent-vacation-unbezahlt {
 	  background: linear-gradient(135deg, #cc6600, #ff9933); /* orangener Verlauf */
 	  color: white;
@@ -129,7 +120,6 @@ $formatter->setPattern('MMMM yyyy');
 	  font-weight: bold;
 	  box-shadow: inset 0 0 5px rgba(0,0,0,0.3);
 	}
-
 	/* Wochenende bleibt unverändert */
 	.weekend {
 	  background-color: #f8d7da;
@@ -138,7 +128,6 @@ $formatter->setPattern('MMMM yyyy');
 	td[title] {
 	  position: relative;
 	}
-
 	td[title]:hover::after {
 	  content: attr(title);
 	  position: absolute;
@@ -154,7 +143,6 @@ $formatter->setPattern('MMMM yyyy');
 	  z-index: 1000;
 	  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
 	}
-
 	td[title]:hover::before {
 	  content: '';
 	  position: absolute;
@@ -164,16 +152,13 @@ $formatter->setPattern('MMMM yyyy');
 	  border: 5px solid transparent;
 	  border-top-color: #333;
 	}
-
     .month-navigation { margin: 20px auto; text-align: left; }
     .month-navigation a { padding: 10px 15px; font-size: 16px; background-color: #FFD700; color: #000; text-decoration: none; border-radius: 4px; margin: 0 5px; }
     .month-navigation a:hover { background-color: #FFC107; }
     .month-navigation span { font-size: 18px; font-weight: bold; margin-left: 10px; }
   </style>
-</head>
-<body>
-  <?php include 'nav.php'; ?>
-  <main>
+
+    <main>
     <h1>Fahrer Abwesenheiten</h1>
     <button onclick="openModal('fahrerAbwesenheitModal')">Abwesenheit eintragen</button>
 	<?php if (isset($_GET['success']) && $_GET['success'] == 1): ?>
@@ -301,5 +286,6 @@ $formatter->setPattern('MMMM yyyy');
                         document.querySelector('.nav-links').classList.toggle('active');
                 });
     </script>
+
 </body>
 </html>

--- a/public/benutzerverwaltung.php
+++ b/public/benutzerverwaltung.php
@@ -65,12 +65,10 @@ foreach ($spalten as $spalte) {
     }
 }
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Benutzerverwaltung | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Benutzerverwaltung';
+include __DIR__ . '/../includes/layout.php';
+?>
     <style>
         .switch {
             position: relative;
@@ -98,9 +96,7 @@ foreach ($spalten as $spalte) {
             transform: translateX(20px);
         }
     </style>
-</head>
-<body>
-<?php include 'nav.php'; ?>
+
 <h1>Benutzerverwaltung</h1>
 
 <?php if (isset($updateMessage)): ?>
@@ -162,5 +158,6 @@ foreach ($spalten as $spalte) {
         document.querySelector('.nav-links').classList.toggle('active');
     });
 </script>
+
 </body>
 </html>

--- a/public/dienstplan_erstellung.php
+++ b/public/dienstplan_erstellung.php
@@ -96,14 +96,10 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     }
 }
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dienstplan erstellen | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Dienstplan erstellen';
+include __DIR__ . '/../includes/layout.php';
+?>
     <style>
         .success {
             color: green;
@@ -160,10 +156,8 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             margin-left: 10px;
         }
     </style>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
       <h1>Dienstplan erstellen</h1>
   
       <?php if (isset($success)): ?><div class="success"><?= $success ?></div><?php endif; ?>
@@ -215,5 +209,6 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
           <button type="submit">Speichern</button>
       </form>
     </main>
+
 </body>
 </html>

--- a/public/edit_service.php
+++ b/public/edit_service.php
@@ -60,16 +60,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 ?>
+<?php
+$title = 'Wartung bearbeiten';
+include __DIR__ . '/../includes/layout.php';
+?>
 
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wartung bearbeiten | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
-</head>
-<body>
+
     <main>
         <h1>Wartung bearbeiten</h1>
         <form method="POST">
@@ -88,5 +84,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <button type="submit">Speichern</button>
         </form>
     </main>
+
 </body>
 </html>

--- a/public/fahrer.php
+++ b/public/fahrer.php
@@ -40,18 +40,13 @@ $stmtMsg = $pdo->prepare("SELECT * FROM fahrer_mitteilungen WHERE gueltig_bis >=
 $stmtMsg->execute();
 $mitteilung = $stmtMsg->fetch(PDO::FETCH_ASSOC);
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fahrerübersicht | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Fahrerübersicht';
+include __DIR__ . '/../includes/layout.php';
+?>
     <script src="js/modal.js"></script>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
         <h1>Fahrerübersicht</h1>
 
         <?php if (!empty($mitteilung)): ?>
@@ -137,5 +132,6 @@ $mitteilung = $stmtMsg->fetch(PDO::FETCH_ASSOC);
             document.querySelector('.nav-links')?.classList.toggle('active');
         });
     </script>
+
 </body>
 </html>

--- a/public/fahrer_bearbeiten.php
+++ b/public/fahrer_bearbeiten.php
@@ -115,14 +115,11 @@ $stmt->execute([$fahrer_id]);
 $gesamt_urlaubstage = $stmt->fetchColumn();
 
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fahrer bearbeiten | DRIVE</title>
+<?php
+$title = 'Fahrer bearbeiten';
+include __DIR__ . '/../includes/layout.php';
+?>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <link rel="stylesheet" href="css/custom.css">
     <script src="js/modal.js"></script>
     <style>
         .form-section {
@@ -230,10 +227,8 @@ $gesamt_urlaubstage = $stmt->fetchColumn();
             border-collapse: collapse;
         }
     </style>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main class="grid-container">
+
+        <main class="grid-container">
         <section class="section">
             <h2>Persönliche Daten</h2>
             <?php if ($error): ?>
@@ -401,5 +396,6 @@ $gesamt_urlaubstage = $stmt->fetchColumn();
 			});
 		});
     </script>
+
 </body>
 </html>

--- a/public/fahrer_umsatz.php
+++ b/public/fahrer_umsatz.php
@@ -69,13 +69,10 @@ $stmtUmsatz = $pdo->prepare("
 $stmtUmsatz->execute([$fahrer_id, $start_date, $end_date]);
 $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fahrer Umsatz | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Fahrer Umsatz';
+include __DIR__ . '/../includes/layout.php';
+?>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <style>
         :root {
@@ -86,25 +83,21 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             --border-color: #ccc;
             --text-muted: #555;
         }
-
         body {
             font-family: Arial, sans-serif;
             background-color: #f9f9f9;
             margin: 0;
             padding: 0;
         }
-
         h1, h2, h3 {
             margin-top: 0;
         }
-
         .section-container {
             display: flex;
             flex-wrap: wrap;
             gap: 20px;
             margin-bottom: 20px;
         }
-
         .section-container section {
             flex: 1;
             padding: 16px;
@@ -113,13 +106,11 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             background-color: white;
             box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
         }
-
         @media (max-width: 768px) {
             .section-container {
                 flex-direction: column;
             }
         }
-
         form.flex-container {
             display: flex;
             flex-wrap: wrap;
@@ -131,12 +122,10 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             border-radius: 10px;
             margin-bottom: 20px;
         }
-
         form.flex-container label {
             font-weight: bold;
             margin-bottom: 5px;
         }
-
         form.flex-container select,
         form.flex-container input[type="date"] {
             padding: 6px;
@@ -144,7 +133,6 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             border-radius: 5px;
             font-size: 1rem;
         }
-
         button {
             padding: 8px 12px;
             font-size: 1rem;
@@ -152,11 +140,9 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             border-radius: 5px;
             cursor: pointer;
         }
-
         button i {
             margin-right: 6px;
         }
-
         .action-btn {
             background-color: var(--highlight-color);
             color: var(--highlight-text);
@@ -166,36 +152,29 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             display: inline-flex;
             align-items: center;
         }
-
         .action-btn:hover {
             background-color: #f7c600;
         }
-
         table {
             width: 100%;
             border-collapse: collapse;
             background-color: white;
         }
-
         table th, table td {
             padding: 10px;
             border: 1px solid var(--border-color);
             text-align: center;
         }
-
         table th {
             background-color: var(--highlight-color);
             color: var(--highlight-text);
         }
-
         .modal, .modal-overlay {
             display: none;
         }
-
         .modal.active, .modal-overlay.active {
             display: block;
         }
-
         .modal {
             position: fixed;
             top: 10%;
@@ -209,7 +188,6 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
             z-index: 1000;
         }
-
         .modal-overlay {
             position: fixed;
             top: 0;
@@ -219,7 +197,6 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             background: rgba(0, 0, 0, 0.4);
             z-index: 999;
         }
-
         .modal input,
         .modal textarea {
             width: 100%;
@@ -229,35 +206,28 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
             border: 1px solid var(--border-color);
             border-radius: 5px;
         }
-
         .modal button {
             margin-top: 10px;
             font-size: 1rem;
         }
-
         .text-muted {
             font-size: 0.85rem;
             color: var(--text-muted);
         }
-
         .btn-primary {
             background-color: var(--primary-color);
             color: white;
         }
-
         .btn-secondary {
             background-color: var(--light-grey);
             color: var(--text-muted);
         }
-
         .btn-secondary:hover {
             background-color: #e1e1e1;
         }
     </style>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
         <h1>Umsätze</h1>
 
         <!-- Fahrerwechsel und Zeitraum -->
@@ -681,5 +651,6 @@ $umsatzDaten = $stmtUmsatz->fetchAll(PDO::FETCH_ASSOC);
 			document.getElementById('modalOverlay').classList.remove('active');
 		}
     </script>
+
 </body>
 </html>

--- a/public/fahrer_vergleich.php
+++ b/public/fahrer_vergleich.php
@@ -50,19 +50,15 @@ $stmt_wochentagsumsatz = $pdo->prepare($sql_wochentagsumsatz);
 $stmt_wochentagsumsatz->execute();
 $result_wochentagsumsatz = $stmt_wochentagsumsatz->fetchAll(PDO::FETCH_ASSOC);
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Fahrer-Vergleich</title>
+<?php
+$title = 'Fahrer-Vergleich';
+include __DIR__ . '/../includes/layout.php';
+?>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <link rel="stylesheet" href="css/custom.css">
     <script src="js/modal.js"></script>
-</head>
-<body>
-  	<?php include 'nav.php'; ?>
-	<main>
+
+  		<main>
     <h2>Vergleich Fahrer-Statistik</h2>
     <form method="get">
         <label for="fahrer">Fahrer auswählen:</label>
@@ -128,5 +124,6 @@ $result_wochentagsumsatz = $stmt_wochentagsumsatz->fetchAll(PDO::FETCH_ASSOC);
         });
     </script>
   </main>
+
 </body>
 </html>

--- a/public/fahrzeug_bearbeiten.php
+++ b/public/fahrzeug_bearbeiten.php
@@ -97,18 +97,13 @@ $historieStmt = $pdo->prepare("
 $historieStmt->execute([$id]);
 $historie = $historieStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
+<?php
+$title = 'Fahrzeug bearbeiten';
+include __DIR__ . '/../includes/layout.php';
+?>
 
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fahrzeug bearbeiten | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
         <h1>Fahrzeug bearbeiten</h1>
         <section>
             <h2>Fahrzeugdaten</h2>
@@ -203,5 +198,6 @@ $historie = $historieStmt->fetchAll(PDO::FETCH_ASSOC);
             </table>
         </section>
     </main>
+
 </body>
 </html>

--- a/public/fahrzeug_overview.php
+++ b/public/fahrzeug_overview.php
@@ -6,18 +6,13 @@ require_once 'modals/process_vehicle.php';
 $stmt = $pdo->query("SELECT * FROM Fahrzeuge ORDER BY Konzessionsnummer ASC");
 $fahrzeuge = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fahrzeugübersicht | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Fahrzeugübersicht';
+include __DIR__ . '/../includes/layout.php';
+?>
     <script src="js/modal.js"></script>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
         <h1>Fahrzeugübersicht</h1>
         <div class="button-group">
             <button class="btn" onclick="openModal('vehicleModal')">Neues Fahrzeug hinzufügen</button>
@@ -58,5 +53,6 @@ $fahrzeuge = $stmt->fetchAll(PDO::FETCH_ASSOC);
         </table>
     </main>
     <?php include 'modals/add_vehicle_modal.php'; ?>
+
 </body>
 </html>

--- a/public/fahrzeuge.php
+++ b/public/fahrzeuge.php
@@ -75,14 +75,11 @@ $stmt->execute();
 $wartung_kommend = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
+<?php
+$title = 'Fahrzeuge';
+include __DIR__ . '/../includes/layout.php';
+?>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fahrzeuge | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
     <script src="js/modal.js"></script>
     <style>
         .fahrzeug.limousine {
@@ -95,10 +92,8 @@ $wartung_kommend = $stmt->fetchAll(PDO::FETCH_ASSOC);
             background-color: #f8d7da; /* Rot */
         }
     </style>
-</head>
-<body>
-	<?php include 'nav.php'; ?>
-    <main class="with_sidebar">
+
+	    <main class="with_sidebar">
 		<h1><i class="fas fa-taxi"></i> Fahrzeugbesetzung</h1>
 		<?php include 'buttons.php'; ?>
 		
@@ -198,5 +193,6 @@ $wartung_kommend = $stmt->fetchAll(PDO::FETCH_ASSOC);
                         document.querySelector('.nav-links').classList.toggle('active');
                 });
     </script>
+
 </body>
 </html>

--- a/public/fines_management.php
+++ b/public/fines_management.php
@@ -117,19 +117,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_fine'])) {
 
 $drivers = fetchDriversWithFines($pdo);
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<?php
+$title = 'Bußgeldverwaltung';
+include __DIR__ . '/../includes/layout.php';
+?>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="css/custom.css">
-    <title>Bußgeldverwaltung | Drive</title>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
     <h1>Bußgeldverwaltung</h1>
 
     <?php if (!empty($successMessage)): ?>
@@ -279,5 +273,6 @@ $drivers = fetchDriversWithFines($pdo);
 			}
 		});
     </script>
+
 </body>
 </html>

--- a/public/login.php
+++ b/public/login.php
@@ -35,17 +35,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Wenn weder Benutzer noch Fahrer erfolgreich waren
     $error = 'Ungültige Anmeldedaten!';
 }
+
+$title = 'Login';
+$showNav = false;
+include __DIR__ . '/../includes/layout.php';
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
     <link rel="stylesheet" href="css/index.css">
-</head>
-<body>
     <div class="wrapper">
         <header>
             <img src="images/4884-logo.png" alt="Ihr Leipzig Taxi 4884" class="logo">

--- a/public/mitarbeiter_management.php
+++ b/public/mitarbeiter_management.php
@@ -51,14 +51,10 @@ if (isset($_GET['edit'])) {
 $stmt = $pdo->query("SELECT * FROM mitarbeiter_zentrale ORDER BY nachname ASC");
 $mitarbeiterListe = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mitarbeiterverwaltung | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Mitarbeiterverwaltung';
+include __DIR__ . '/../includes/layout.php';
+?>
     <style>
 		.form-wrapper {
             max-width: 500px;
@@ -134,10 +130,8 @@ $mitarbeiterListe = $stmt->fetchAll(PDO::FETCH_ASSOC);
             text-decoration: underline;
         }
     </style>
-</head>
-<body>
-	<?php include 'nav.php'; ?>
-	<main>
+
+		<main>
 		<div class="form-wrapper">
 			<h2><?= $editMitarbeiter ? 'Mitarbeiter bearbeiten' : 'Mitarbeiter hinzufügen' ?></h2>
 			<?php if ($error): ?><div class="error"><?= $error ?></div><?php endif; ?>
@@ -200,5 +194,6 @@ $mitarbeiterListe = $stmt->fetchAll(PDO::FETCH_ASSOC);
 			</tbody>
 		</table>
 	</main>
+
 </body>
 </html>

--- a/public/register.php
+++ b/public/register.php
@@ -31,14 +31,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Registrierung | DRIVE</title>
-</head>
-<body>
+<?php
+$title = 'Registrierung';
+$showNav = false;
+include __DIR__ . '/../includes/layout.php';
+?>
+
+
     <h1>Benutzer registrieren</h1>
     <?php if ($error): ?>
         <p style="color: red;"><?= htmlspecialchars($error) ?></p>
@@ -59,5 +58,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <button type="submit">Registrieren</button>
     </form>
     <p><a href="index.php">Zum Login</a></p>
+
 </body>
 </html>

--- a/public/sauberkeit.php
+++ b/public/sauberkeit.php
@@ -91,21 +91,16 @@ $vorherigesJahr = ($monat == 1) ? $jahr - 1 : $jahr;
 $nächsterMonat = ($monat == 12) ? 1 : $monat + 1;
 $nächstesJahr = ($monat == 12) ? $jahr + 1 : $jahr;
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
+<?php
+$title = 'Fahrzeugsauberkeit';
+include __DIR__ . '/../includes/layout.php';
+?>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fahrzeugsauberkeit | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
 	<style>
 	.month-navigation {
 		  margin: 20px auto;
 		  text-align: left;
 		}
-
 		.month-navigation a {
 		  padding: 10px 15px;
 		  font-size: 16px;
@@ -115,21 +110,17 @@ $nächstesJahr = ($monat == 12) ? $jahr + 1 : $jahr;
 		  border-radius: 4px;
 		  margin: 0 5px;
 		}
-
 		.month-navigation a:hover {
 		  background-color: #FFC107;
 		}
-
 		.month-navigation span {
 		  font-size: 18px;
 		  font-weight: bold;
 		  margin-left: 10px;
 		}
 	</style>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-	<main>
+
+    	<main>
     <h1>Fahrzeugkontrollen - Sauberkeit</h1>
 
     <div class="month-navigation">
@@ -181,5 +172,6 @@ $nächstesJahr = ($monat == 12) ? $jahr + 1 : $jahr;
         </tbody>
     </table>
 	</main>
+
 </body>
 </html>

--- a/public/schulungsverwaltung.php
+++ b/public/schulungsverwaltung.php
@@ -336,22 +336,16 @@ if ($nextTermin) {
 }
 
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<?php
+$title = 'Schulungsverwaltung';
+include __DIR__ . '/../includes/layout.php';
+?>
     <!-- Bootstrap CSS für einheitliches Styling -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="css/custom.css">
-    <title>Schulungsverwaltung</title>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
 		<div class="alert alert-info text-center">
 		<strong>Teilnehmer gesamt:</strong> <?php echo $stats['gesamt']; ?> |
 		<strong>Bestanden:</strong> <?php echo $stats['bestanden']; ?> |
@@ -576,5 +570,6 @@ if ($nextTermin) {
             modalInput.value = deleteId;
         });
     </script>
+
 </body>
 </html>

--- a/public/service.php
+++ b/public/service.php
@@ -30,19 +30,13 @@ try {
     die("Datenbankfehler: " . $e->getMessage());
 }
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wartungen | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Wartungen';
+include __DIR__ . '/../includes/layout.php';
+?>
     <script src="js/modal.js"></script>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
         <h1>Wartungen</h1>
 		
 		<button class="btn" onclick="openModal('maintenanceModal')">Wartungstermin</button>
@@ -91,5 +85,6 @@ try {
             document.querySelector('.nav-links').classList.toggle('active');
         });
     </script>
+
 </body>
 </html>

--- a/public/shift_control.php
+++ b/public/shift_control.php
@@ -52,14 +52,10 @@ if (isset($_GET['edit'])) {
 $stmt = $pdo->query("SELECT * FROM schichten ORDER BY startzeit ASC");
 $schichtenListe = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Schichtenverwaltung | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
+<?php
+$title = 'Schichtenverwaltung';
+include __DIR__ . '/../includes/layout.php';
+?>
     <style>
         .form-wrapper {
             max-width: 500px;
@@ -135,10 +131,8 @@ $schichtenListe = $stmt->fetchAll(PDO::FETCH_ASSOC);
             text-decoration: underline;
         }
     </style>
-</head>
-<body>
-	<?php include 'nav.php'; ?>
-	<main>
+
+		<main>
 		<div class="form-wrapper">
 			<h2><?= $editSchicht ? 'Schicht bearbeiten' : 'Schicht hinzufügen' ?></h2>
 			<?php if ($error): ?><div class="error"><?= $error ?></div><?php endif; ?>
@@ -204,5 +198,6 @@ $schichtenListe = $stmt->fetchAll(PDO::FETCH_ASSOC);
 			</tbody>
 		</table>
 	</main>
+
 </body>
 </html>

--- a/public/statistik.php
+++ b/public/statistik.php
@@ -135,20 +135,14 @@ $stmt_fahrer_unter_264 = $pdo->prepare($sql_fahrer_unter_264);
 $stmt_fahrer_unter_264->execute();
 $result_fahrer_unter_264 = $stmt_fahrer_unter_264->fetchAll(PDO::FETCH_ASSOC);
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fahrerstatistik | Drive</title>
+<?php
+$title = 'Fahrerstatistik';
+include __DIR__ . '/../includes/layout.php';
+?>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <link rel="stylesheet" href="css/custom.css">
     <script src="js/modal.js"></script>
-</head>
-<body>
-	<?php include 'nav.php'; ?>
-    <main>
+
+	    <main>
     <h2>Fahrerstatistik</h2>
     <p>Hier sind die Statistiken zu den Fahrern basierend auf Umsatz, Effizienz und Arbeitstagen.</p>
     
@@ -259,5 +253,6 @@ $result_fahrer_unter_264 = $stmt_fahrer_unter_264->fetchAll(PDO::FETCH_ASSOC);
     </table>
 </main>
 </main>
+
 </body>
 </html>

--- a/public/umsatz_dashboard.php
+++ b/public/umsatz_dashboard.php
@@ -91,18 +91,13 @@ $totalFirmen = count($gesamtProFirma); // Anzahl der Firmen
 $itemWidth = 200; // Breite pro Eintrag in Pixel
 $totalWidth = $totalFirmen * $itemWidth; // Gesamtbreite
 ?>
+<?php
+$title = 'Umsatz nach Firma';
+include __DIR__ . '/../includes/layout.php';
+?>
 
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Umsatz nach Firma | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
         <h1>Umsatz-Dashboard nach Firma</h1>
         
         <!-- Zeitraum auswählen -->
@@ -250,5 +245,6 @@ $totalWidth = $totalFirmen * $itemWidth; // Gesamtbreite
 		}
 	}
 	</script>
+
 </body>
 </html>

--- a/public/vehicle_transfer.php
+++ b/public/vehicle_transfer.php
@@ -27,19 +27,13 @@ try {
     die("Datenbankfehler: " . $e->getMessage());
 }
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
+<?php
+$title = 'FahrzeugÜbergaben';
+include __DIR__ . '/../includes/layout.php';
+?>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>FahrzeugÜbergaben | DRIVE</title>
-    <link rel="stylesheet" href="css/custom.css">
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main>
+
+        <main>
         <h1>FahrzeugÜbergaben</h1>
 
         <table>
@@ -71,5 +65,6 @@ try {
             </tbody>
         </table>
     </main>
+
 </body>
 </html>

--- a/public/verwaltung_abwesenheit.php
+++ b/public/verwaltung_abwesenheit.php
@@ -132,29 +132,23 @@ function getAbwesenheitsKuerzel($typ) {
     }
 }
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Verwaltung Abwesenheiten | DRIVE</title>
+<?php
+$title = 'Verwaltung Abwesenheiten';
+include __DIR__ . '/../includes/layout.php';
+?>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-  <link rel="stylesheet" href="css/custom.css">
   <script>
     const typesWithPeriod = <?= json_encode($ABSENCE_TYPES['period']); ?>;
     const typesWithTimePoint = <?= json_encode($ABSENCE_TYPES['time_point']); ?>;
     const typesWithTimeRange = <?= json_encode($ABSENCE_TYPES['time_range']); ?>;
-
     function updateFormFields() {
       const typ = document.getElementById('typ').value;
       const isPeriod = typesWithPeriod.includes(typ);
       const isTimePoint = typesWithTimePoint.includes(typ);
       const isTimeRange = typesWithTimeRange.includes(typ);
-
       document.getElementById('zeitraum').style.display = isPeriod ? 'block' : 'none';
       document.getElementById('zeitpunkt').style.display = isTimePoint ? 'block' : 'none';
       document.getElementById('zeitspanne').style.display = isTimeRange ? 'block' : 'none';
-
       document.getElementById('startdatum').disabled = !isPeriod;
       document.getElementById('enddatum').disabled = !isPeriod;
       document.getElementById('tag_zeitpunkt').disabled = !isTimePoint;
@@ -163,7 +157,6 @@ function getAbwesenheitsKuerzel($typ) {
       document.getElementById('von_uhrzeit').disabled = !isTimeRange;
       document.getElementById('bis_uhrzeit').disabled = !isTimeRange;
     }
-
     window.addEventListener('load', updateFormFields);
   </script>
   <style>
@@ -191,10 +184,8 @@ function getAbwesenheitsKuerzel($typ) {
         font-weight: bold;
     }
 	</style>
-</head>
-<body>
-  <?php include 'nav.php'; ?>
-  <main>
+
+    <main>
     <h1>Abwesenheiten Verwaltung</h1>
 
     <?php if ($anzeigenAbwesenheiten): ?>
@@ -335,6 +326,7 @@ function getAbwesenheitsKuerzel($typ) {
 		</form>
 	  </div>
 	</div>
+
 
 </body>
 </html>

--- a/public/xrechnung_viewer.php
+++ b/public/xrechnung_viewer.php
@@ -2,16 +2,12 @@
 // xrechnung_viewer.php
 require_once '../includes/bootstrap.php';
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>XRechnung-Viewer</title>
+<?php
+$title = 'XRechnung-Viewer';
+include __DIR__ . '/../includes/layout.php';
+?>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="css/custom.css">
 	<style>
 		.upload-area {
 			border: 2px dashed #00aaff;
@@ -22,18 +18,14 @@ require_once '../includes/bootstrap.php';
 			cursor: pointer;
 			transition: background-color 0.3s ease;
 		}
-
 		.upload-area.dragover {
 			background-color: #d0efff;
 		}
-
 		.upload-icon {
 			color: #007acc;
 		}
 	</style>
-</head>
-<body>
-<?php include 'nav.php'; ?>
+
 
 <main class="container py-5">
     <h1 class="mb-4">XRechnung-Viewer</h1>
@@ -336,6 +328,7 @@ uploadArea.addEventListener('drop', function(e) {
     }
 });
 </script>
+
 
 </body>
 </html>

--- a/public/zentrale_dashboard.php
+++ b/public/zentrale_dashboard.php
@@ -171,17 +171,13 @@ $unreadAbwesenheiten = $unreadStmt->fetchAll(PDO::FETCH_ASSOC);
 $unreadCount = count($unreadAbwesenheiten);
 
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Zentrale Dashboard | DRIVE</title>
+<?php
+$title = 'Zentrale Dashboard';
+include __DIR__ . '/../includes/layout.php';
+?>
     <!-- Font Awesome Einbindung -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <!-- Bisheriges CSS -->
-    <link rel="stylesheet" href="css/custom.css">
     <script src="js/modal.js"></script>
     <style>
                 /* Krankheitszellen */
@@ -189,24 +185,20 @@ $unreadCount = count($unreadAbwesenheiten);
 		  background-color: #d4edda;
 		  color: #155724;
 		}
-
 		/* Urlaubszellen */
 		.dashboard-table .absent-vacation {
 		  background-color: #fff3cd;
 		  color: #856404;
 		}
-		
 		/*Wochenende*/
 		.dashboard-table .weekend {
 		  background-color: #f8d7da;
 		  color: #721c24;
 		}
-
 		.month-navigation {
 		  margin: 20px auto;
 		  text-align: left;
 		}
-
 		.month-navigation a {
 		  padding: 10px 15px;
 		  font-size: 16px;
@@ -216,21 +208,17 @@ $unreadCount = count($unreadAbwesenheiten);
 		  border-radius: 4px;
 		  margin: 0 5px;
 		}
-
 		.month-navigation a:hover {
 		  background-color: #FFC107;
 		}
-
 		.month-navigation span {
 		  font-size: 18px;
 		  font-weight: bold;
 		  margin-left: 10px;
 		}
 		</style>
-</head>
-<body>
-    <?php include 'nav.php'; ?>
-    <main class="with_sidebar">
+
+        <main class="with_sidebar">
         <h1>Zentrale Dashboard</h1>
 		
 		<?php if ($unreadCount > 0): ?>
@@ -374,6 +362,7 @@ $unreadCount = count($unreadAbwesenheiten);
 	document.querySelector('.nav-links').classList.toggle('active');
 	});
 	</script>
+
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Allow hiding the navigation bar via `$showNav` in the shared layout
- Switch the login page to use the common layout and disable navigation
- Convert additional administrative pages to the shared layout with unified titles and navigation

## Testing
- `php -l includes/layout.php`
- `php -l public/abwesenheit_fahrer.php public/benutzerverwaltung.php public/dienstplan_erstellung.php public/edit_service.php public/fahrer.php public/fahrer_bearbeiten.php public/fahrer_umsatz.php public/fahrer_vergleich.php public/fahrzeug_bearbeiten.php public/fahrzeug_overview.php public/fahrzeuge.php public/fines_management.php public/mitarbeiter_management.php public/register.php public/sauberkeit.php public/schulungsverwaltung.php public/service.php public/shift_control.php public/statistik.php public/umsatz_dashboard.php public/vehicle_transfer.php public/verwaltung_abwesenheit.php public/xrechnung_viewer.php public/zentrale_dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_68b7d37350b0832b81d34bf2216d401b