### PR TITLE
Make dropdown menu links black

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -189,7 +189,7 @@ nav {
 }
 
 .dropdown-menu a {
-	color: var(--color-text);
+        color: var(--color-black) !important;
 }
 .dropdown:hover .dropdown-menu {
     display: block;
@@ -841,7 +841,7 @@ nav {
 }
 
 .dropdown-menu a {
-	color: var(--color-text);
+        color: var(--color-black) !important;
 }
 
 .dropdown:hover .dropdown-menu {


### PR DESCRIPTION
## Summary
- Ensure dropdown submenu links default to black by setting `.dropdown-menu a` color to `var(--color-black)`

## Testing
- `npx --yes stylelint public/css/custom.css` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ee9c4348832b831199de417ec054