### PR TITLE
Set driver role in PHP routes

### DIFF
--- a/public/driver/dashboard.php
+++ b/public/driver/dashboard.php
@@ -2,6 +2,9 @@
 //public/driver/dashboard.php
 require_once '../../includes/bootstrap.php';
 
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 // Fehleranzeige aktivieren (nur für Debugging, in Produktion entfernen)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/public/driver/delete_entry.php
+++ b/public/driver/delete_entry.php
@@ -1,6 +1,9 @@
 <?php
 require_once '../../includes/bootstrap.php'; // Lädt Authentifizierung und Datenbankverbindung
 
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 // Überprüfung, ob der Benutzer eingeloggt ist
 if (!isset($_SESSION['user_id'])) {
     die('Fehler: Keine gültige Session. Bitte erneut anmelden.');

--- a/public/driver/fahrzeug.php
+++ b/public/driver/fahrzeug.php
@@ -4,6 +4,9 @@ use PHPMailer\PHPMailer\Exception;
 	
 require_once '../../includes/bootstrap.php'; // Datenbankverbindung und Authentifizierung
 
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 if (!isset($_SESSION['user_id'])) {
     die('Fehler: Keine gültige Session. Bitte erneut anmelden.');
 }

--- a/public/driver/personal.php
+++ b/public/driver/personal.php
@@ -5,6 +5,9 @@ error_reporting(E_ALL);
 
 require_once '../../includes/bootstrap.php'; // Verbindung und Authentifizierung
 
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 // Session prüfen
 if (session_status() === PHP_SESSION_NONE) {
     session_start();

--- a/public/driver/process_urlaub_antrag.php
+++ b/public/driver/process_urlaub_antrag.php
@@ -4,6 +4,10 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 session_start();
+
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 require_once '../../includes/db.php'; // Passe den Pfad an, falls nötig.
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/public/driver/send_message.php
+++ b/public/driver/send_message.php
@@ -1,6 +1,9 @@
 <?php
 require_once '../../includes/bootstrap.php';
 
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 if (!isDriver()) {
     header('Location: ../index.php');
     exit;

--- a/public/driver/statistics.php
+++ b/public/driver/statistics.php
@@ -1,6 +1,9 @@
 <?php
 require_once '../../includes/bootstrap.php';
 
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 // Fehleranzeige aktivieren (nur für Debugging, in Produktion entfernen)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/public/driver/umsatz_erfassen.php
+++ b/public/driver/umsatz_erfassen.php
@@ -1,6 +1,9 @@
 <?php
 require_once '../../includes/bootstrap.php';
 
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 if ($_SESSION['user_role'] !== 'fahrer') {
     header("Location: ../index.php");
     exit();

--- a/public/driver/update_entry.php
+++ b/public/driver/update_entry.php
@@ -1,6 +1,9 @@
 <?php
 require_once '../../includes/bootstrap.php'; // Datenbankverbindung
 
+// Rolle für diese Route festlegen (einfachste Variante)
+$_SESSION['rolle'] = 'Fahrer';
+
 // Fehleranzeige aktivieren (nur für Debugging, in Produktion entfernen)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);


### PR DESCRIPTION
## Summary
- Set `$_SESSION['rolle']` to `Fahrer` across driver-facing routes
- Keep role assignment near bootstrapping or session start for consistency

## Testing
- `php -l public/driver/dashboard.php && php -l public/driver/personal.php && php -l public/driver/fahrzeug.php && php -l public/driver/umsatz_erfassen.php && php -l public/driver/statistics.php && php -l public/driver/process_urlaub_antrag.php && php -l public/driver/send_message.php && php -l public/driver/delete_entry.php && php -l public/driver/update_entry.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7f1fdb174832ba550d6bfb6768717