### PR TITLE
Route Postfach links through controller

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -215,7 +215,7 @@ $menuEntries = [
     ],
     [
         'label' => 'Postfach',
-        'url' => 'messages/inbox.php',
+        'url' => 'messages/inbox',
         'roles' => ['Fahrer'],
         'context' => 'bottom',
         'icon' => 'bi-envelope',

--- a/public/driver/driver-nav.php
+++ b/public/driver/driver-nav.php
@@ -10,7 +10,7 @@
     <ul>
         <li><a href="dashboard.php">Dashboard</a></li>
         <li><a href="umsatz_erfassen.php">Umsatz erfassen</a></li>
-        <li><a href="../messages/inbox.php">Postfach</a></li>
+        <li><a href="../messages/inbox">Postfach</a></li>
         <li><a href="../logout.php">Logout</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
## Summary
- Point Postfach navigation entries to the controller route instead of the PHP file.

## Testing
- `php -l includes/navigation.php`
- `php -l public/driver/driver-nav.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7f4d6b7f8832bb1a9a71cc071bb59