### PR TITLE
Add hover color for dropdown menu links

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -191,6 +191,10 @@ nav {
 .dropdown-menu a {
         color: var(--color-black) !important;
 }
+.dropdown-menu a:hover {
+        color: var(--color-primary);
+}
+
 .dropdown:hover .dropdown-menu {
     display: block;
 }
@@ -843,6 +847,10 @@ nav {
 .dropdown-menu a {
         color: var(--color-black) !important;
 }
+.dropdown-menu a:hover {
+        color: var(--color-primary);
+}
+
 
 .dropdown:hover .dropdown-menu {
     display: block;


### PR DESCRIPTION
## Summary
- Style dropdown menu links to show primary color on hover for better visual feedback

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f806da9c832ba6ecd221107e0587