### PR TITLE
Use direct child selector for dropdown hover menus

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -195,7 +195,7 @@ nav {
         color: var(--color-primary);
 }
 
-.dropdown:hover .dropdown-menu {
+.dropdown:hover > .dropdown-menu {
     display: block;
 }
 
@@ -852,7 +852,7 @@ nav {
 }
 
 
-.dropdown:hover .dropdown-menu {
+.dropdown:hover > .dropdown-menu {
     display: block;
 }
 


### PR DESCRIPTION
## Summary
- scope dropdown hover rule to direct children so deeper menus stay hidden
- retain nested dropdown rule for deeper menu levels

## Testing
- `npx stylelint public/css/custom.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f8dc1dfc832baa162e18b9f34dda