### PR TITLE
Refactor navigation for Verwaltung and Sonstiges

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -77,25 +77,13 @@ $menuEntries = [
                 'roles' => ['Admin', 'Mitarbeiter'],
                 'icon' => 'bi-speedometer',
             ],
-            [
-                'label' => 'Schulung',
-                'url' => 'schulungsverwaltung.php',
-                'roles' => ['Admin'],
-                'icon' => 'bi-journal-text',
-            ],
-            [
-                'label' => 'XRechnung',
-                'url' => 'xrechnung_viewer.php',
-                'roles' => ['Admin', 'Mitarbeiter'],
-                'icon' => 'bi-file-earmark-text',
-            ],
-            [
-                'label' => 'Verwaltung',
-                'url'   => 'verwaltung_abwesenheit.php',
-                'roles' => ['Admin', 'Mitarbeiter', 'Zentrale', 'Abrechnung'],
-                'icon' => 'bi-gear',
-            ],
         ],
+    ],
+    [
+        'label' => 'Verwaltung',
+        'url'   => 'verwaltung_abwesenheit.php',
+        'roles' => ['Admin', 'Mitarbeiter', 'Zentrale', 'Abrechnung'],
+        'icon'  => 'bi-gear',
     ],
     [
         'label' => 'Abrechnung',
@@ -150,6 +138,25 @@ $menuEntries = [
                 'url' => 'mitarbeiter_management.php',
                 'roles' => ['Zentrale'],
                 'icon' => 'bi-people',
+            ],
+        ],
+    ],
+    [
+        'label' => 'Sonstiges',
+        'roles' => ['Admin', 'Mitarbeiter'],
+        'icon' => 'bi-three-dots',
+        'children' => [
+            [
+                'label' => 'Schulung',
+                'url' => 'schulungsverwaltung.php',
+                'roles' => ['Admin'],
+                'icon' => 'bi-journal-text',
+            ],
+            [
+                'label' => 'XRechnung',
+                'url' => 'xrechnung_viewer.php',
+                'roles' => ['Admin', 'Mitarbeiter'],
+                'icon' => 'bi-file-earmark-text',
             ],
         ],
     ],


### PR DESCRIPTION
## Summary
- Remove Schulung, XRechnung and Verwaltung from Fahrbetrieb menu
- Add top-level Verwaltung entry for shared management functions
- Introduce Sonstiges menu with Schulung and XRechnung items

## Testing
- `php -l includes/navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7fa88e4e0832bb904de045850080f