### PR TITLE
Fix dropdown hover color and clean duplicate styles

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -194,7 +194,7 @@ nav {
         color: var(--color-black) !important;
 }
 .dropdown-menu a:hover {
-        color: var(--color-primary);
+        color: var(--color-primary) !important;
 }
 
 .dropdown:hover > .dropdown-menu {
@@ -846,36 +846,6 @@ nav {
     margin: 0;
     padding: 0;
     justify-content: flex-end;
-}
-
-.dropdown-menu a {
-        color: var(--color-black) !important;
-}
-.dropdown-menu a:hover {
-        color: var(--color-primary);
-}
-
-
-.dropdown:hover > .dropdown-menu {
-    display: block;
-}
-
-/* Verschachtelte Dropdowns */
-.dropdown-menu .dropdown {
-    position: relative;
-}
-
-.dropdown-menu .dropdown-menu {
-    display: none;
-    position: absolute;
-    top: 0;
-    left: 100%; /* Seitlich vom übergeordneten Menü */
-    background-color: #ffffff;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-}
-
-.dropdown-menu .dropdown:hover > .dropdown-menu {
-    display: block;
 }
 
 /*********************************************


### PR DESCRIPTION
## Summary
- Ensure dropdown menu hover links use the primary color with `!important`
- Remove redundant dropdown style block to prevent inconsistent overrides

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd851ef8832b8421547752323ea8