### PR TITLE
Move central dashboard menu entry

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -71,12 +71,6 @@ $menuEntries = [
                     ],
                 ],
             ],
-            [
-                'label' => 'Zentralendashboard',
-                'url' => 'zentrale_dashboard.php',
-                'roles' => ['Admin', 'Mitarbeiter'],
-                'icon' => 'bi-speedometer',
-            ],
         ],
     ],
     [
@@ -121,6 +115,12 @@ $menuEntries = [
         'roles' => ['Zentrale'],
         'icon' => 'bi-building',
         'children' => [
+            [
+                'label' => 'Zentralendashboard',
+                'url' => 'zentrale_dashboard.php',
+                'roles' => ['Admin', 'Mitarbeiter'],
+                'icon' => 'bi-speedometer',
+            ],
             [
                 'label' => 'Dienstplan',
                 'url' => 'dienstplan_erstellung.php',


### PR DESCRIPTION
## Summary
- Move Zentralendashboard menu entry from Fahrbetrieb to Zentrale

## Testing
- `php -l includes/navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7ffbb7b1c832b89e9f955c8c00135