### PR TITLE
Use absolute path for inbox navigation links

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -10,7 +10,7 @@ $menuEntries = [
     ],
     [
         'label' => 'Postfach',
-        'url' => 'messages/inbox',
+        'url' => '/messages/inbox',
         'roles' => ['Admin', 'Mitarbeiter', 'Fahrer', 'Zentrale', 'Abrechnung'],
         'icon' => 'bi-envelope',
     ],

--- a/public/driver/driver-nav.php
+++ b/public/driver/driver-nav.php
@@ -10,7 +10,7 @@
     <ul>
         <li><a href="dashboard.php">Dashboard</a></li>
         <li><a href="umsatz_erfassen.php">Umsatz erfassen</a></li>
-        <li><a href="../messages/inbox">Postfach</a></li>
+        <li><a href="/messages/inbox">Postfach</a></li>
         <li><a href="../logout.php">Logout</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
## Summary
- Point "Postfach" menu to `/messages/inbox`
- Update driver navigation to use the same absolute inbox path

## Testing
- `php -l includes/navigation.php`
- `php -l public/driver/driver-nav.php`


------
https://chatgpt.com/codex/tasks/task_e_68b802b4cec4832ba20057b0472e6b85