### PR TITLE
Use relative path for inbox navigation link

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -10,7 +10,7 @@ $menuEntries = [
     ],
     [
         'label' => 'Postfach',
-        'url' => '/messages/inbox',
+        'url' => 'messages/inbox',
         'roles' => ['Admin', 'Mitarbeiter', 'Fahrer', 'Zentrale', 'Abrechnung'],
         'icon' => 'bi-envelope',
     ],


### PR DESCRIPTION
## Summary
- use relative path for messages inbox in navigation menu

## Testing
- `php -l includes/navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68b806329f18832b9199549c40cc0d26