### PR TITLE
Use new postfach.php path in navigation menus

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -10,7 +10,7 @@ $menuEntries = [
     ],
     [
         'label' => 'Postfach',
-        'url' => 'messages/inbox',
+        'url' => 'postfach.php',
         'roles' => ['Admin', 'Mitarbeiter', 'Fahrer', 'Zentrale', 'Abrechnung'],
         'icon' => 'bi-envelope',
     ],
@@ -222,7 +222,7 @@ $menuEntries = [
     ],
     [
         'label' => 'Postfach',
-        'url' => 'messages/inbox',
+        'url' => 'postfach.php',
         'roles' => ['Fahrer'],
         'context' => 'bottom',
         'icon' => 'bi-envelope',

--- a/public/driver/driver-nav.php
+++ b/public/driver/driver-nav.php
@@ -10,7 +10,7 @@
     <ul>
         <li><a href="dashboard.php">Dashboard</a></li>
         <li><a href="umsatz_erfassen.php">Umsatz erfassen</a></li>
-        <li><a href="/messages/inbox">Postfach</a></li>
+        <li><a href="/postfach.php">Postfach</a></li>
         <li><a href="../logout.php">Logout</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
## Summary
- Route the Postfach menu entry to `postfach.php`
- Update driver menu to link to the new Postfach URL

## Testing
- `php -l includes/navigation.php`
- `php -l public/driver/driver-nav.php`


------
https://chatgpt.com/codex/tasks/task_e_68b818009104832bae0b5a414e976413