### PR TITLE
Prevent duplicate session initialization

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'db.php';
 
-session_start();
+if (session_status() === PHP_SESSION_NONE) { session_start(); }
 
 function isLoggedIn() {
     return isset($_SESSION['user_id']);

--- a/public/postfach.php
+++ b/public/postfach.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 
 require_once __DIR__ . '/../includes/config.php';
 require_once __DIR__ . '/../includes/auth.php';


### PR DESCRIPTION
## Summary
- Initialize session conditionally in `includes/auth.php`
- Remove redundant session start from `public/postfach.php`

## Testing
- `php -l includes/auth.php`
- `php -l public/postfach.php`


------
https://chatgpt.com/codex/tasks/task_e_68b83269ddb0832ba817e74e85c2b442