### PR TITLE
Use require for db connection

### DIFF
--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'auth.php'; // Prüft, ob der Benutzer eingeloggt ist
-require_once 'db.php';   // Stellt die Datenbankverbindung bereit
+require 'db.php';   // Stellt die Datenbankverbindung bereit
 
 // Seiten, bei denen das require_once nicht erfolgen soll
 $excludedPages = ['login.php', 'register.php'];


### PR DESCRIPTION
## Summary
- ensure includes/bootstrap.php uses `require` for db.php so $pdo is available even when included inside functions

## Testing
- `php -l includes/bootstrap.php`
- `php -r 'require "includes/bootstrap.php"; function test(){require "includes/bootstrap.php"; echo isset($pdo)?"defined":"undefined";} test();'` *(fails: Datenbankverbindung fehlgeschlagen: SQLSTATE[HY000] [2002] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b833ab5394832bb82d32ac12e088f0