### PR TITLE
Ensure menu entries array before rendering menu

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -309,6 +309,7 @@ function buildMenu(array $items, array $userRoles, string $currentPath = ''): st
 function renderMenu($currentRole, $secondaryRoles, $context = 'top', $currentPath = '')
 {
     global $menuEntries;
+    $menuEntries = is_array($menuEntries) ? $menuEntries : [];
 
     if (is_string($secondaryRoles)) {
         $secondary = array_filter(array_map('trim', explode(',', $secondaryRoles)));


### PR DESCRIPTION
## Summary
- Guard `$menuEntries` with `is_array` before building navigation items

## Testing
- `php -l includes/navigation.php`
- `php public/postfach.php` (fails: SQLSTATE[HY000] [2002] Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68b839a7dd04832b9c873e03eb4ecf36