### PR TITLE
Ensure inbox navigation reflects user role

### DIFF
--- a/public/postfach.php
+++ b/public/postfach.php
@@ -2,12 +2,15 @@
 
 require_once __DIR__ . '/../includes/config.php';
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/user_check.php';
 require_once __DIR__ . '/../app/Models/Message.php';
 
 use App\Models\Message;
 
 function showInbox(): void
 {
+    global $sekundarRolle;
+
     if (!isset($_SESSION['user_id'])) {
         header('Location: /login.php');
         exit;


### PR DESCRIPTION
## Summary
- Include user_check.php in postfach script for role information
- Expose $sekundarRolle before loading inbox navigation

## Testing
- `php -l public/postfach.php`


------
https://chatgpt.com/codex/tasks/task_e_68b83b562ee4832b9a5792e45fc79c20