### PR TITLE
Add compose view and routing for messages

### DIFF
--- a/app/Views/messages/compose.php
+++ b/app/Views/messages/compose.php
@@ -1,0 +1,27 @@
+<?php
+// Formular zum Verfassen einer neuen Nachricht
+?>
+<?php include __DIR__ . '/../../../public/head.php'; ?>
+<body>
+    <?php include __DIR__ . '/../../../public/nav.php'; ?>
+    <main>
+        <h1>Neue Nachricht</h1>
+        <form method="post" action="/postfach.php?action=store">
+            <div>
+                <label for="recipient_id">Empfänger</label>
+                <input type="text" id="recipient_id" name="recipient_id" required>
+            </div>
+            <div>
+                <label for="subject">Betreff</label>
+                <input type="text" id="subject" name="subject" required>
+            </div>
+            <div>
+                <label for="body">Nachricht</label>
+                <textarea id="body" name="body" required></textarea>
+            </div>
+            <button type="submit">Senden</button>
+        </form>
+    </main>
+</body>
+</html>
+

--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -7,6 +7,12 @@
     <?php include __DIR__ . '/../../../public/nav.php'; ?>
     <main>
         <h1>Ungelesene Nachrichten</h1>
+
+        <p><a href="/postfach.php?action=compose">Neue Nachricht</a></p>
+
+        <?php if (!empty($success)): ?>
+            <p class="success">Nachricht gesendet.</p>
+        <?php endif; ?>
         <?php if (empty($messages)): ?>
             <p>Keine ungelesenen Nachrichten.</p>
         <?php else: ?>


### PR DESCRIPTION
## Summary
- add compose view with fields for recipient, subject and body
- extend postfach routing to display compose form and redirect to inbox after saving
- link from inbox to compose and show send success message

## Testing
- `php -l app/Views/messages/compose.php && php -l app/Views/messages/inbox.php && php -l public/postfach.php`


------
https://chatgpt.com/codex/tasks/task_e_68b83bc94394832b8019d925a1fa74f3