### PR TITLE
Normalize role casing for navigation menu

### DIFF
--- a/includes/user_check.php
+++ b/includes/user_check.php
@@ -15,15 +15,14 @@ try {
     $stmt->execute([$userId]);
     $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
-    // Primärrolle in der Session speichern
-    if ($user && isset($user['Rolle'])) {
-        $_SESSION['rolle'] = $user['Rolle'];
-    } else {
-        $_SESSION['rolle'] = 'Keine'; // Fallback, falls keine Rolle gesetzt ist
-    }
+    // Primärrolle in der Session speichern, normalisiert
+    $_SESSION['rolle'] = ucfirst(strtolower($user['Rolle'] ?? ''));
 
-    // Sekundarrolle setzen
-    $sekundarRolle = $user['SekundarRolle'] ?? 'Keine'; // Standardwert, wenn keine Sekundarrolle vorhanden
+    // Sekundärrollen normalisieren und als Array bereitstellen
+    $sekundarRolle = array_map(
+        fn($r) => ucfirst(strtolower($r)),
+        explode(',', $user['SekundarRolle'] ?? '')
+    );
 
     // Name in der Session speichern
     if ($user && isset($user['Name'])) {

--- a/public/nav.php
+++ b/public/nav.php
@@ -1,9 +1,13 @@
 <?php
 require_once '../includes/navigation.php';
 $currentPage = basename($_SERVER['PHP_SELF']);
+
+$primaryRole    = $_SESSION['rolle'] ?? '';
+$secondaryRoles = $sekundarRolle ?? [];
+
 renderMenu(
-    $_SESSION['rolle'] ?? '',
-    $sekundarRolle ?? '',
+    $primaryRole,
+    $secondaryRoles,
     'top',
     $currentPage
 );


### PR DESCRIPTION
## Summary
- Normalize primary and secondary user roles to ensure consistent casing
- Pass normalized role values to `renderMenu()` when building navigation

## Testing
- `php -l includes/user_check.php`
- `php -l public/nav.php`
- `php -r 'session_start(); $_SESSION["rolle"]="Admin"; $sekundarRolle=["Mitarbeiter"]; $_SERVER["PHP_SELF"]="dashboard.php"; chdir("public"); include "nav.php";'`


------
https://chatgpt.com/codex/tasks/task_e_68b83dde8f94832bb8dd718e92878ee6