### PR TITLE
Populate compose message with recipient selection

### DIFF
--- a/app/Views/messages/compose.php
+++ b/app/Views/messages/compose.php
@@ -9,7 +9,11 @@
         <form method="post" action="/postfach.php?action=store">
             <div>
                 <label for="recipient_id">Empfänger</label>
-                <input type="text" id="recipient_id" name="recipient_id" required>
+                <select id="recipient_id" name="recipient_id" required>
+                    <?php foreach ($recipients as $r): ?>
+                        <option value="<?= $r['BenutzerID'] ?>"><?= htmlspecialchars($r['Name']) ?></option>
+                    <?php endforeach; ?>
+                </select>
             </div>
             <div>
                 <label for="subject">Betreff</label>

--- a/public/postfach.php
+++ b/public/postfach.php
@@ -31,6 +31,19 @@ function showCompose(): void
         exit;
     }
 
+    global $pdo;
+
+    $isDriver = isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'fahrer';
+
+    if ($isDriver) {
+        $stmt = $pdo->prepare('SELECT b.BenutzerID, b.Name FROM Benutzer b JOIN message_permissions mp ON b.BenutzerID = mp.recipient_id WHERE mp.driver_id = ? ORDER BY b.Name');
+        $stmt->execute([(int) $_SESSION['user_id']]);
+    } else {
+        $stmt = $pdo->query('SELECT BenutzerID, Name FROM Benutzer ORDER BY Name');
+    }
+
+    $recipients = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
     include __DIR__ . '/../app/Views/messages/compose.php';
 }
 


### PR DESCRIPTION
## Summary
- Load potential message recipients from the database in `showCompose`, filtering by `message_permissions` for drivers
- Replace recipient text input with a populated `<select>` in the compose view

## Testing
- `php -l public/postfach.php`
- `php -l app/Views/messages/compose.php`
- `php -r 'session_start(); $_SESSION["user_id"]=1; $_SESSION["user_role"]="fahrer"; $_POST["recipient_id"]=2; $_POST["subject"]="Test"; $_POST["body"]="Hello"; include "public/postfach.php"; saveMessage();'` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b83ecbdb40832b92883f592cffc759