### PR TITLE
Implement conversation-based inbox with AJAX

### DIFF
--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -1,33 +1,44 @@
 <?php
-// expects $messages
+// expects $conversations and optional $conversation
 ?>
 <?php include __DIR__ . '/../../../public/head.php'; ?>
 <link rel="stylesheet" href="/css/messages.css">
 <body>
     <?php include __DIR__ . '/../../../public/nav.php'; ?>
     <main>
-        <h1>Ungelesene Nachrichten</h1>
-
-        <p><a href="/postfach.php?action=compose">Neue Nachricht</a></p>
+        <h1>Nachrichten</h1>
 
         <?php if (!empty($success)): ?>
             <p class="success">Nachricht gesendet.</p>
         <?php endif; ?>
-        <?php if (empty($messages)): ?>
-            <p>Keine ungelesenen Nachrichten.</p>
-        <?php else: ?>
-            <?php foreach ($messages as $msg): ?>
-                <div class="message">
-                    <h2><?= htmlspecialchars($msg['subject']) ?></h2>
-                    <p><em>Von <?= htmlspecialchars($msg['sender_name']) ?> am <?= htmlspecialchars($msg['created_at']) ?></em></p>
-                    <p><?= nl2br(htmlspecialchars($msg['body'])) ?></p>
-                    <form method="post" action="/messages/mark-as-read">
-                        <input type="hidden" name="id" value="<?= $msg['id'] ?>">
-                        <button type="submit">Als gelesen markieren</button>
-                    </form>
+
+        <div class="inbox-container">
+            <div class="conversation-list">
+                <ul>
+                    <?php foreach ($conversations as $conv): ?>
+                        <li data-other-id="<?= htmlspecialchars($conv['other_id']) ?>">
+                            <strong><?= htmlspecialchars($conv['other_name']) ?></strong><br>
+                            <span><?= htmlspecialchars($conv['subject']) ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <div class="conversation-panel" id="conversation-panel">
+                <a href="/postfach.php?action=compose" class="new-message-btn">Neue Nachricht</a>
+                <div id="conversation-content">
+                    <?php if (!empty($conversation)): ?>
+                        <?php foreach ($conversation as $msg): ?>
+                            <div class="message">
+                                <p><strong><?= htmlspecialchars($msg['sender_name']) ?></strong> am <?= htmlspecialchars($msg['created_at']) ?></p>
+                                <p><?= nl2br(htmlspecialchars($msg['body'])) ?></p>
+                            </div>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
                 </div>
-            <?php endforeach; ?>
-        <?php endif; ?>
+            </div>
+        </div>
     </main>
+    <script src="/js/messages.js"></script>
 </body>
 </html>
+

--- a/public/api/messages.php
+++ b/public/api/messages.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../../includes/config.php';
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../app/Models/Message.php';
+
+use App\Models\Message;
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthenticated']);
+    exit;
+}
+
+$otherId = (int) ($_GET['other_id'] ?? 0);
+if ($otherId === 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing other_id']);
+    exit;
+}
+
+$userId = (int) $_SESSION['user_id'];
+$messages = Message::getMessagesBetween($userId, $otherId);
+echo json_encode($messages);
+

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -36,3 +36,39 @@
     color: #666;
 }
 
+.inbox-container {
+    display: flex;
+    height: 80vh;
+}
+
+.inbox-container .conversation-list {
+    flex: 0 0 30%;
+    max-width: 300px;
+    border-right: 1px solid #ccc;
+    overflow-y: auto;
+    padding: 1rem;
+}
+
+.inbox-container .conversation-list ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.inbox-container .conversation-list li + li {
+    margin-top: 0.5rem;
+}
+
+.conversation-panel {
+    flex: 1;
+    position: relative;
+    padding: 1rem;
+    overflow-y: auto;
+}
+
+.conversation-panel .new-message-btn {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+}
+

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var items = document.querySelectorAll('.conversation-list [data-other-id]');
+  var content = document.getElementById('conversation-content');
+
+  function escapeHtml(str) {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  items.forEach(function (item) {
+    item.addEventListener('click', function () {
+      var otherId = item.getAttribute('data-other-id');
+      fetch('/api/messages.php?other_id=' + encodeURIComponent(otherId))
+        .then(function (res) { return res.json(); })
+        .then(function (messages) {
+          var html = '';
+          messages.forEach(function (msg) {
+            html += '<div class="message">' +
+              '<p><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>' +
+              '<p>' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>' +
+              '</div>';
+          });
+          content.innerHTML = html;
+        });
+    });
+  });
+});
+

--- a/public/postfach.php
+++ b/public/postfach.php
@@ -17,7 +17,12 @@ function showInbox(): void
     }
 
     $userId = (int) $_SESSION['user_id'];
-    $messages = Message::getUnreadByUser($userId);
+    $conversations = Message::getConversationsByUser($userId);
+    $conversation = [];
+    if (isset($_GET['with'])) {
+        $otherId = (int) $_GET['with'];
+        $conversation = Message::getMessagesBetween($userId, $otherId);
+    }
     $success = ($_GET['success'] ?? '') !== '';
     include __DIR__ . '/../app/Views/messages/inbox.php';
 }


### PR DESCRIPTION
## Summary
- Replace unread message list with conversation view and optional conversation loading
- Add AJAX endpoint and client script to fetch messages dynamically
- Style new two-column inbox layout and message panel

## Testing
- `php -l public/postfach.php`
- `php -l app/Views/messages/inbox.php`
- `php -l public/api/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_68b841789ae0832b9c6ce9f221c93fde