### PR TITLE
Add compose modal to inbox and load recipients

### DIFF
--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -7,6 +7,9 @@
     <?php include __DIR__ . '/../../../public/nav.php'; ?>
     <main>
         <h1>Nachrichten</h1>
+        <div style="text-align: right;">
+            <button class="btn btn-primary" onclick="openModal('composeModal')">Neue Nachricht</button>
+        </div>
 
         <?php if (!empty($success)): ?>
             <p class="success">Nachricht gesendet.</p>
@@ -24,7 +27,6 @@
                 </ul>
             </div>
             <div class="conversation-panel" id="conversation-panel">
-                <a href="/postfach.php?action=compose" class="new-message-btn">Neue Nachricht</a>
                 <div id="conversation-content">
                     <?php if (!empty($conversation)): ?>
                         <?php foreach ($conversation as $msg): ?>
@@ -37,7 +39,9 @@
                 </div>
             </div>
         </div>
+        <?php include __DIR__ . '/../../../public/modals/message_compose.php'; ?>
     </main>
+    <script src="/js/modal.js"></script>
     <script src="/js/messages.js"></script>
 </body>
 </html>

--- a/public/modals/message_compose.php
+++ b/public/modals/message_compose.php
@@ -1,0 +1,22 @@
+<div class="modal" id="composeModal">
+    <div class="modal-content">
+        <span class="close" onclick="closeModal('composeModal')">&times;</span>
+        <h2>Neue Nachricht</h2>
+        <form action="/postfach.php?action=store" method="post">
+            <label for="recipient_id">Empfänger</label>
+            <select id="recipient_id" name="recipient_id" required>
+                <?php foreach ($recipients as $r): ?>
+                    <option value="<?= htmlspecialchars($r['BenutzerID']) ?>"><?= htmlspecialchars($r['Name']) ?></option>
+                <?php endforeach; ?>
+            </select>
+            <br>
+            <label for="subject">Betreff</label>
+            <input type="text" id="subject" name="subject" required>
+            <br>
+            <label for="body">Nachricht</label>
+            <textarea id="body" name="body" required></textarea>
+            <br>
+            <button type="submit">Senden</button>
+        </form>
+    </div>
+</div>

--- a/public/postfach.php
+++ b/public/postfach.php
@@ -23,6 +23,20 @@ function showInbox(): void
         $otherId = (int) $_GET['with'];
         $conversation = Message::getMessagesBetween($userId, $otherId);
     }
+    
+    global $pdo;
+
+    $isDriver = isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'fahrer';
+
+    if ($isDriver) {
+        $stmt = $pdo->prepare('SELECT b.BenutzerID, b.Name FROM Benutzer b JOIN message_permissions mp ON b.BenutzerID = mp.recipient_id WHERE mp.driver_id = ? ORDER BY b.Name');
+        $stmt->execute([$userId]);
+    } else {
+        $stmt = $pdo->query('SELECT BenutzerID, Name FROM Benutzer ORDER BY Name');
+    }
+
+    $recipients = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
     $success = ($_GET['success'] ?? '') !== '';
     include __DIR__ . '/../app/Views/messages/inbox.php';
 }


### PR DESCRIPTION
## Summary
- Load available message recipients in `showInbox` and pass them to the view
- Add `public/modals/message_compose.php` with compose form
- Extend inbox view to include modal, trigger button, and JS files

## Testing
- `php -l public/postfach.php`
- `php -l app/Views/messages/inbox.php`
- `php -l public/modals/message_compose.php`


------
https://chatgpt.com/codex/tasks/task_e_68b842580b74832bb7e3a5bcb3c394fa