### PR TITLE
Use absolute paths for navigation and head includes

### DIFF
--- a/public/head.php
+++ b/public/head.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../includes/bootstrap.php';
+require_once __DIR__ . '/../includes/bootstrap.php';
 ?>
 <!doctype html>
 <html lang="de">

--- a/public/nav.php
+++ b/public/nav.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../includes/navigation.php';
+require_once __DIR__ . '/../includes/navigation.php';
 $currentPage = basename($_SERVER['PHP_SELF']);
 
 $primaryRole    = $_SESSION['rolle'] ?? '';


### PR DESCRIPTION
## Summary
- Load navigation include using an absolute path to avoid path resolution issues.
- Load bootstrap initialization with an absolute path, ensuring assets with SRI hashes are available for navigation styling.

## Testing
- `php -l public/nav.php`
- `php -l public/head.php`
- `php -l public/postfach.php`


------
https://chatgpt.com/codex/tasks/task_e_68b843543b5c832b99b02c9a5f4984ac