### PR TITLE
Add message previews and chat bubble styling

### DIFF
--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -21,7 +21,8 @@
                     <?php foreach ($conversations as $conv): ?>
                         <li data-other-id="<?= htmlspecialchars($conv['other_id']) ?>">
                             <strong><?= htmlspecialchars($conv['other_name']) ?></strong><br>
-                            <span><?= htmlspecialchars($conv['subject']) ?></span>
+                            <span><?= htmlspecialchars($conv['subject']) ?></span><br>
+                            <span class="preview"><?= htmlspecialchars(mb_strimwidth($conv['body'], 0, 40, '…')) ?></span>
                         </li>
                     <?php endforeach; ?>
                 </ul>

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -72,3 +72,21 @@
     right: 1rem;
 }
 
+.message {
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    max-width: 75%;
+}
+
+.message.sent {
+    background-color: #dcf8c6;
+    margin-left: auto;
+    text-align: right;
+}
+
+.message.received {
+    background-color: #ffffff;
+    border: 1px solid #ccc;
+    margin-right: auto;
+}
+

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -11,13 +11,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
   items.forEach(function (item) {
     item.addEventListener('click', function () {
-      var otherId = item.getAttribute('data-other-id');
+      var otherId = parseInt(item.getAttribute('data-other-id'), 10);
       fetch('/api/messages.php?other_id=' + encodeURIComponent(otherId))
         .then(function (res) { return res.json(); })
         .then(function (messages) {
           var html = '';
           messages.forEach(function (msg) {
-            html += '<div class="message">' +
+            var cls = (msg.sender_id === otherId) ? 'received' : 'sent';
+            html += '<div class="message ' + cls + '">' +
               '<p><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>' +
               '<p>' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>' +
               '</div>';
@@ -26,5 +27,9 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
   });
+
+  if (items.length > 0) {
+    items[0].click();
+  }
 });
 


### PR DESCRIPTION
## Summary
- Display last message preview in inbox conversation list
- Auto-load first conversation and tag messages as sent or received
- Style chat bubbles for sent and received messages

## Testing
- `php -l app/Views/messages/inbox.php`
- `node --check public/js/messages.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b848233ea4832ba018fae5ed86e51c