### PR TITLE
Persist secondary roles in session and use in navigation

### DIFF
--- a/includes/user_check.php
+++ b/includes/user_check.php
@@ -24,6 +24,8 @@ try {
         explode(',', $user['SekundarRolle'] ?? '')
     );
 
+    $_SESSION['sekundarRolle'] = $sekundarRolle;
+
     // Name in der Session speichern
     if ($user && isset($user['Name'])) {
         $_SESSION['user_name'] = $user['Name'];

--- a/public/nav.php
+++ b/public/nav.php
@@ -1,9 +1,10 @@
 <?php
 require_once __DIR__ . '/../includes/navigation.php';
+global $sekundarRolle;
 $currentPage = basename($_SERVER['PHP_SELF']);
 
 $primaryRole    = $_SESSION['rolle'] ?? '';
-$secondaryRoles = $sekundarRolle ?? [];
+$secondaryRoles = $_SESSION['sekundarRolle'] ?? [];
 
 renderMenu(
     $primaryRole,


### PR DESCRIPTION
## Summary
- Save normalized secondary roles to the session during user checks
- Pull secondary roles from session for navigation rendering and keep global variable for legacy use

## Testing
- `php -l includes/user_check.php`
- `php -l public/nav.php`
- `php -l public/postfach.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8498fbfc8832bba49830e6e18d79d