### PR TITLE
Align nav items to the right

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -133,7 +133,7 @@ body {
 nav {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     background: var(--color-nav-bg);
     padding: 10px 20px;
     color: #ffffff;
@@ -787,7 +787,7 @@ main {
 nav {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     /* Neuer dezenter Farbverlauf */
     background: var(--gradient-nav);
     padding: 10px 20px;


### PR DESCRIPTION
## Summary
- Align navigation bar content to the right by setting `justify-content: flex-end`

## Testing
- `php -l public/nav.php`
- `php -l public/head.php`


------
https://chatgpt.com/codex/tasks/task_e_68b836333f2c832ba62cd2b74b5f433f