### PR TITLE
Ensure session roles set before rendering messages views

### DIFF
--- a/app/Views/messages/compose.php
+++ b/app/Views/messages/compose.php
@@ -1,5 +1,6 @@
 <?php
 // Formular zum Verfassen einer neuen Nachricht
+require_once __DIR__ . '/../../../includes/user_check.php';
 ?>
 <?php include __DIR__ . '/../../../public/head.php'; ?>
 <body>

--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -1,5 +1,6 @@
 <?php
 // expects $conversations and optional $conversation
+require_once __DIR__ . '/../../../includes/user_check.php';
 ?>
 <?php include __DIR__ . '/../../../public/head.php'; ?>
 <link rel="stylesheet" href="/css/messages.css">


### PR DESCRIPTION
## Summary
- Ensure messages compose and inbox views include user_check so session roles are set before rendering navigation

## Testing
- `php -l app/Views/messages/inbox.php`
- `php -l app/Views/messages/compose.php`


------
https://chatgpt.com/codex/tasks/task_e_68b84d0b0228832ba2bcbb67a6a5d9f8