### PR TITLE
Handle secondary role array without explode

### DIFF
--- a/public/verwaltung_abwesenheit.php
+++ b/public/verwaltung_abwesenheit.php
@@ -67,7 +67,7 @@ $formatter = new IntlDateFormatter('de_DE', IntlDateFormatter::LONG, IntlDateFor
 $formatter->setPattern('MMMM yyyy');
 
 // Ungenehmigte Abwesenheiten anzeigen, wenn Benutzer Zugriff hat
-$rollen = array_map('trim', explode(',', $sekundarRolle));
+$rollen = array_map('trim', (array)$sekundarRolle);
 $anzeigenAbwesenheiten = in_array('Verwaltung', $rollen, true);
 $offeneAbwesenheiten = [];
 


### PR DESCRIPTION
## Summary
- Use `$sekundarRolle` directly as an array to avoid explode errors when roles already provided as array

## Testing
- `php -l public/verwaltung_abwesenheit.php`
- `php verwaltung_abwesenheit.php` *(fails: SQLSTATE[HY000] [2002] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b84e3f49e8832ba7d2cda4933f9ae6