### PR TITLE
Use layout for mailbox views

### DIFF
--- a/app/Views/messages/compose.php
+++ b/app/Views/messages/compose.php
@@ -1,11 +1,7 @@
 <?php
 // Formular zum Verfassen einer neuen Nachricht
-require_once __DIR__ . '/../../../includes/user_check.php';
 ?>
-<?php include __DIR__ . '/../../../public/head.php'; ?>
-<body>
-    <?php include __DIR__ . '/../../../public/nav.php'; ?>
-    <main>
+<main>
         <h1>Neue Nachricht</h1>
         <form method="post" action="/postfach.php?action=store">
             <div>

--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -1,12 +1,8 @@
 <?php
 // expects $conversations and optional $conversation
-require_once __DIR__ . '/../../../includes/user_check.php';
 ?>
-<?php include __DIR__ . '/../../../public/head.php'; ?>
 <link rel="stylesheet" href="/css/messages.css">
-<body>
-    <?php include __DIR__ . '/../../../public/nav.php'; ?>
-    <main>
+<main>
         <h1>Nachrichten</h1>
         <div style="text-align: right;">
             <button class="btn btn-primary" onclick="openModal('composeModal')">Neue Nachricht</button>

--- a/public/postfach.php
+++ b/public/postfach.php
@@ -38,6 +38,9 @@ function showInbox(): void
     $recipients = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     $success = ($_GET['success'] ?? '') !== '';
+
+    $title = 'Postfach';
+    include __DIR__ . '/../includes/layout.php';
     include __DIR__ . '/../app/Views/messages/inbox.php';
 }
 
@@ -63,6 +66,8 @@ function showCompose(): void
 
     $recipients = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
+    $title = 'Neue Nachricht';
+    include __DIR__ . '/../includes/layout.php';
     include __DIR__ . '/../app/Views/messages/compose.php';
 }
 


### PR DESCRIPTION
## Summary
- Render inbox and compose views through layout in public/postfach.php
- Simplify message views to output only main content

## Testing
- `php -l public/postfach.php`
- `php -l app/Views/messages/inbox.php`
- `php -l app/Views/messages/compose.php`


------
https://chatgpt.com/codex/tasks/task_e_68b850915878832b86bb503c18aa17d0