### PR TITLE
Use layout for message views and add extra CSS support

### DIFF
--- a/app/Views/messages/compose.php
+++ b/app/Views/messages/compose.php
@@ -23,6 +23,4 @@
             <button type="submit">Senden</button>
         </form>
     </main>
-</body>
-</html>
 

--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -1,7 +1,6 @@
 <?php
 // expects $conversations and optional $conversation
 ?>
-<link rel="stylesheet" href="/css/messages.css">
 <main>
         <h1>Nachrichten</h1>
         <div style="text-align: right;">
@@ -41,6 +40,4 @@
     </main>
     <script src="/js/modal.js"></script>
     <script src="/js/messages.js"></script>
-</body>
-</html>
 

--- a/public/head.php
+++ b/public/head.php
@@ -10,5 +10,12 @@ require_once __DIR__ . '/../includes/bootstrap.php';
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="stylesheet" href="css/custom.css?v=<?= filemtime(__DIR__ . '/css/custom.css'); ?>">
+    <?php
+    if (!empty($extraCss)) {
+        foreach ((array) $extraCss as $css) {
+            echo '<link rel="stylesheet" href="' . htmlspecialchars($css) . '">';
+        }
+    }
+    ?>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 </head>

--- a/public/postfach.php
+++ b/public/postfach.php
@@ -39,6 +39,7 @@ function showInbox(): void
 
     $success = ($_GET['success'] ?? '') !== '';
 
+    $extraCss = 'css/messages.css';
     $title = 'Postfach';
     include __DIR__ . '/../includes/layout.php';
     include __DIR__ . '/../app/Views/messages/inbox.php';
@@ -66,6 +67,7 @@ function showCompose(): void
 
     $recipients = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
+    $extraCss = 'css/messages.css';
     $title = 'Neue Nachricht';
     include __DIR__ . '/../includes/layout.php';
     include __DIR__ . '/../app/Views/messages/compose.php';
@@ -116,3 +118,5 @@ if ($action === 'store') {
 } else {
     showInbox();
 }
+
+echo '</body></html>';


### PR DESCRIPTION
## Summary
- Remove inline stylesheet and closing tags from message inbox and compose templates
- Allow additional styles via `$extraCss` in `head.php`
- Load mailbox views through `postfach.php` with title, navigation, and global layout

## Testing
- `php -l app/Views/messages/inbox.php`
- `php -l app/Views/messages/compose.php`
- `php -l public/head.php`
- `php -l public/postfach.php`


------
https://chatgpt.com/codex/tasks/task_e_68b853ddf254832b8e7d1d0e4935e0bb