### PR TITLE
Refactor message views to use centralized layout

### DIFF
--- a/app/Controllers/MessageController.php
+++ b/app/Controllers/MessageController.php
@@ -17,7 +17,11 @@ class MessageController
 
         $userId = (int) $_SESSION['user_id'];
         $conversations = Message::getConversationsByUser($userId);
+        $title = 'Nachrichten';
+        $extraCss = 'css/messages.css';
+        include __DIR__ . '/../../includes/layout.php';
         include __DIR__ . '/../Views/messages/index.php';
+        echo "</body></html>";
     }
 
     public function show(int $otherId): void
@@ -30,7 +34,11 @@ class MessageController
 
         $userId = (int) $_SESSION['user_id'];
         $messages = Message::getMessagesBetween($userId, $otherId);
+        $title = 'Nachrichtenverlauf';
+        $extraCss = 'css/messages.css';
+        include __DIR__ . '/../../includes/layout.php';
         include __DIR__ . '/../Views/messages/show.php';
+        echo "</body></html>";
     }
 
     public function inbox(): void
@@ -42,8 +50,18 @@ class MessageController
         }
 
         $userId = (int) $_SESSION['user_id'];
-        $messages = Message::getUnreadByUser($userId);
+        $conversations = Message::getConversationsByUser($userId);
+        $conversation = [];
+        if (isset($_GET['with'])) {
+            $otherId = (int) $_GET['with'];
+            $conversation = Message::getMessagesBetween($userId, $otherId);
+        }
+        $success = ($_GET['success'] ?? '') !== '';
+        $title = 'Postfach';
+        $extraCss = 'css/messages.css';
+        include __DIR__ . '/../../includes/layout.php';
         include __DIR__ . '/../Views/messages/inbox.php';
+        echo "</body></html>";
     }
 
     public function markAsRead(): void

--- a/app/Views/messages/compose.php
+++ b/app/Views/messages/compose.php
@@ -2,25 +2,25 @@
 // Formular zum Verfassen einer neuen Nachricht
 ?>
 <main>
-        <h1>Neue Nachricht</h1>
-        <form method="post" action="/postfach.php?action=store">
-            <div>
-                <label for="recipient_id">Empfänger</label>
-                <select id="recipient_id" name="recipient_id" required>
-                    <?php foreach ($recipients as $r): ?>
-                        <option value="<?= $r['BenutzerID'] ?>"><?= htmlspecialchars($r['Name']) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div>
-                <label for="subject">Betreff</label>
-                <input type="text" id="subject" name="subject" required>
-            </div>
-            <div>
-                <label for="body">Nachricht</label>
-                <textarea id="body" name="body" required></textarea>
-            </div>
-            <button type="submit">Senden</button>
-        </form>
-    </main>
+    <h1>Neue Nachricht</h1>
+    <form method="post" action="/postfach.php?action=store">
+        <div>
+            <label for="recipient_id">Empfänger</label>
+            <select id="recipient_id" name="recipient_id" required>
+                <?php foreach ($recipients as $r): ?>
+                    <option value="<?= $r['BenutzerID'] ?>"><?= htmlspecialchars($r['Name']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div>
+            <label for="subject">Betreff</label>
+            <input type="text" id="subject" name="subject" required>
+        </div>
+        <div>
+            <label for="body">Nachricht</label>
+            <textarea id="body" name="body" required></textarea>
+        </div>
+        <button type="submit">Senden</button>
+    </form>
+</main>
 

--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -2,42 +2,42 @@
 // expects $conversations and optional $conversation
 ?>
 <main>
-        <h1>Nachrichten</h1>
-        <div style="text-align: right;">
-            <button class="btn btn-primary" onclick="openModal('composeModal')">Neue Nachricht</button>
+    <h1>Nachrichten</h1>
+    <div style="text-align: right;">
+        <button class="btn btn-primary" onclick="openModal('composeModal')">Neue Nachricht</button>
+    </div>
+
+    <?php if (!empty($success)): ?>
+        <p class="success">Nachricht gesendet.</p>
+    <?php endif; ?>
+
+    <div class="inbox-container">
+        <div class="conversation-list">
+            <ul>
+                <?php foreach ($conversations as $conv): ?>
+                    <li data-other-id="<?= htmlspecialchars($conv['other_id']) ?>">
+                        <strong><?= htmlspecialchars($conv['other_name']) ?></strong><br>
+                        <span><?= htmlspecialchars($conv['subject']) ?></span><br>
+                        <span class="preview"><?= htmlspecialchars(mb_strimwidth($conv['body'], 0, 40, '…')) ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
         </div>
-
-        <?php if (!empty($success)): ?>
-            <p class="success">Nachricht gesendet.</p>
-        <?php endif; ?>
-
-        <div class="inbox-container">
-            <div class="conversation-list">
-                <ul>
-                    <?php foreach ($conversations as $conv): ?>
-                        <li data-other-id="<?= htmlspecialchars($conv['other_id']) ?>">
-                            <strong><?= htmlspecialchars($conv['other_name']) ?></strong><br>
-                            <span><?= htmlspecialchars($conv['subject']) ?></span><br>
-                            <span class="preview"><?= htmlspecialchars(mb_strimwidth($conv['body'], 0, 40, '…')) ?></span>
-                        </li>
+        <div class="conversation-panel" id="conversation-panel">
+            <div id="conversation-content">
+                <?php if (!empty($conversation)): ?>
+                    <?php foreach ($conversation as $msg): ?>
+                        <div class="message">
+                            <p><strong><?= htmlspecialchars($msg['sender_name']) ?></strong> am <?= htmlspecialchars($msg['created_at']) ?></p>
+                            <p><?= nl2br(htmlspecialchars($msg['body'])) ?></p>
+                        </div>
                     <?php endforeach; ?>
-                </ul>
-            </div>
-            <div class="conversation-panel" id="conversation-panel">
-                <div id="conversation-content">
-                    <?php if (!empty($conversation)): ?>
-                        <?php foreach ($conversation as $msg): ?>
-                            <div class="message">
-                                <p><strong><?= htmlspecialchars($msg['sender_name']) ?></strong> am <?= htmlspecialchars($msg['created_at']) ?></p>
-                                <p><?= nl2br(htmlspecialchars($msg['body'])) ?></p>
-                            </div>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </div>
+                <?php endif; ?>
             </div>
         </div>
-        <?php include __DIR__ . '/../../../public/modals/message_compose.php'; ?>
-    </main>
-    <script src="/js/modal.js"></script>
-    <script src="/js/messages.js"></script>
+    </div>
+    <?php include __DIR__ . '/../../../public/modals/message_compose.php'; ?>
+</main>
+<script src="/js/modal.js"></script>
+<script src="/js/messages.js"></script>
 

--- a/app/Views/messages/index.php
+++ b/app/Views/messages/index.php
@@ -9,11 +9,6 @@ if ($selectedUserId && isset($_SESSION['user_id'])) {
     $messages = Message::getMessagesBetween((int) $_SESSION['user_id'], $selectedUserId);
 }
 ?>
-<?php
-$title = 'Nachrichten';
-include __DIR__ . '/../../../includes/layout.php';
-?>
-<link rel="stylesheet" href="/css/messages.css">
 <main class="messages-container">
         <aside class="conversations">
             <h2>Gesprächspartner</h2>
@@ -50,6 +45,4 @@ include __DIR__ . '/../../../includes/layout.php';
             <?php endif; ?>
         </section>
     </main>
-</body>
-</html>
 

--- a/app/Views/messages/show.php
+++ b/app/Views/messages/show.php
@@ -1,28 +1,18 @@
 <?php
 // expects $messages
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Nachrichtenverlauf</title>
-    <link rel="stylesheet" href="/css/custom.css">
-</head>
-<body>
-    <?php include __DIR__ . '/../../../public/nav.php'; ?>
-    <main>
-        <h1>Verlauf</h1>
-        <?php if (empty($messages)): ?>
-            <p>Keine Nachrichten vorhanden.</p>
-        <?php else: ?>
-            <?php foreach ($messages as $msg): ?>
-                <div class="message">
-                    <p><strong><?= htmlspecialchars($msg['sender_name']) ?>:</strong> <?= nl2br(htmlspecialchars($msg['body'])) ?></p>
-                    <p><em><?= htmlspecialchars($msg['created_at']) ?></em></p>
-                </div>
-            <?php endforeach; ?>
-        <?php endif; ?>
-        <p><a href="/messages">Zurück zur Übersicht</a></p>
-    </main>
-</body>
-</html>
+<main>
+    <h1>Verlauf</h1>
+    <?php if (empty($messages)): ?>
+        <p>Keine Nachrichten vorhanden.</p>
+    <?php else: ?>
+        <?php foreach ($messages as $msg): ?>
+            <div class="message">
+                <p><strong><?= htmlspecialchars($msg['sender_name']) ?>:</strong> <?= nl2br(htmlspecialchars($msg['body'])) ?></p>
+                <p><em><?= htmlspecialchars($msg['created_at']) ?></em></p>
+            </div>
+        <?php endforeach; ?>
+    <?php endif; ?>
+    <p><a href="/messages">Zurück zur Übersicht</a></p>
+</main>
+


### PR DESCRIPTION
## Summary
- Move layout rendering for message pages into `MessageController` and `postfach.php`
- Simplify message views (`index`, `show`, `inbox`, `compose`) to output only page content
- Load message styling via `$extraCss` so navigation and CSS remain consistent

## Testing
- `php -l app/Views/messages/index.php`
- `php -l app/Views/messages/show.php`
- `php -l app/Views/messages/inbox.php`
- `php -l app/Views/messages/compose.php`
- `php -l app/Controllers/MessageController.php`
- `php -l public/postfach.php`


------
https://chatgpt.com/codex/tasks/task_e_68b85725c738832b92623929f23b43b0