### PR TITLE
Refactor driver pages to use shared layout

### DIFF
--- a/public/driver/dashboard.php
+++ b/public/driver/dashboard.php
@@ -148,17 +148,15 @@ $naechsteAbrechnung = $stmtAbrechnung->fetch(PDO::FETCH_ASSOC);
 // Mitteilung an alle Fahrer abrufen
 $stmtHinweis = $pdo->query("SELECT * FROM fahrer_mitteilungen WHERE sichtbar = TRUE AND gueltig_bis >= CURDATE() ORDER BY erstellt_am DESC LIMIT 1");
 $fahrerHinweis = $stmtHinweis->fetch(PDO::FETCH_ASSOC);
-?>
 
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dashboard | Fahrer</title>
-    <link rel="stylesheet" href="css/driver-dashboard.css">
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-	<style>
+$title = 'Fahrer Dashboard';
+$extraCss = [
+    'css/driver-dashboard.css',
+    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css'
+];
+include __DIR__ . '/../../includes/layout.php';
+?>
+        <style>
 	/* Grundlayout */
 	body {
 		font-family: 'Arial', sans-serif;
@@ -419,11 +417,8 @@ $fahrerHinweis = $stmtHinweis->fetch(PDO::FETCH_ASSOC);
 	a[href="statistics.php"]:hover {
 		text-decoration: underline;
 	}
-	</style>
+        </style>
 
-</head>
-<body>
-    <?php include 'bottom_nav.php'; ?>
     <main>
         <h1>Willkommen, <?= htmlspecialchars($fahrer['Vorname'] ?? 'Unbekannt') ?></h1>
 		

--- a/public/driver/fahrzeug.php
+++ b/public/driver/fahrzeug.php
@@ -97,17 +97,15 @@ function formatDateTime($datetime) {
     $date = new DateTime($datetime);
     return $date->format('d.m.Y');
 }
-?>
 
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Meine Fahrzeuge | DRIVE</title>
-    <link rel="stylesheet" href="css/driver-dashboard.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-	<style>
+$title = 'Meine Fahrzeuge';
+$extraCss = [
+    'css/driver-dashboard.css',
+    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css'
+];
+include __DIR__ . '/../../includes/layout.php';
+?>
+        <style>
 		body {
 			background: #f6f8fa;
 			font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -223,11 +221,7 @@ function formatDateTime($datetime) {
 				padding: 10px;
 			}
 		}
-	</style>
-
-</head>
-<body>
-    <?php include 'bottom_nav.php'; ?>
+        </style>
 
     <main>
         <h1>🚗 Meine Fahrzeuge</h1>

--- a/public/driver/personal.php
+++ b/public/driver/personal.php
@@ -46,21 +46,20 @@ try {
         WHERE FahrerID = ? 
         ORDER BY startdatum DESC
     ";
-    $stmt = $pdo->prepare($abwesenheitenQuery);
-    $stmt->execute([$fahrer_id]);
-    $abwesenheiten = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$stmt = $pdo->prepare($abwesenheitenQuery);
+$stmt->execute([$fahrer_id]);
+$abwesenheiten = $stmt->fetchAll(PDO::FETCH_ASSOC);
 } catch (PDOException $e) {
     die('Datenbankfehler beim Abrufen der Abwesenheiten: ' . $e->getMessage());
 }
+
+$title = 'Persönliche Daten';
+$extraCss = [
+    'css/driver-dashboard.css',
+    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css'
+];
+include __DIR__ . '/../../includes/layout.php';
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Persönliche Daten | DRIVE</title>
-  <link rel="stylesheet" href="css/driver-dashboard.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <script src="../js/modal.js"></script>
         <style>
 		body {
@@ -251,9 +250,7 @@ try {
 			font-weight: bold;
 		}
 
-	</style>
-</head>
-<body>
+        </style>
   <main>
     <h1>Persönliche Daten</h1>
 	<div class="table-responsive">
@@ -341,7 +338,6 @@ try {
     <p>Mehr Funktionen folgen später!</p>
   </main>
   
-  <?php include 'bottom_nav.php'; ?>
   
   <!-- Modal für Urlaub beantragen -->
   <div id="urlaubModal" class="modal">

--- a/public/driver/send_message.php
+++ b/public/driver/send_message.php
@@ -45,17 +45,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     header('Location: dashboard.php?message_sent=1');
     exit;
 }
+
+$title = 'Nachricht senden';
+$extraCss = ['css/custom.css', 'css/index.css'];
+include __DIR__ . '/../../includes/layout.php';
 ?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Nachricht senden</title>
-    <link rel="stylesheet" href="css/custom.css">
-    <link rel="stylesheet" href="css/index.css">
-</head>
-<body>
-<?php include 'driver-nav.php'; ?>
 <div class="wrapper">
     <h1>Nachricht senden</h1>
     <form method="post">

--- a/public/driver/statistics.php
+++ b/public/driver/statistics.php
@@ -109,20 +109,14 @@ $stmt_ausgaben_nach_art = $pdo->prepare("
 ");
 $stmt_ausgaben_nach_art->execute([$fahrer_id, $start_date, $end_date]);
 $ausgaben_nach_art = $stmt_ausgaben_nach_art->fetch(PDO::FETCH_ASSOC);
+
+$title = 'Statistiken';
+$extraCss = [
+    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css',
+    'css/driver-dashboard.css'
+];
+include __DIR__ . '/../../includes/layout.php';
 ?>
-
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Statistiken</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="css/driver-dashboard.css">
-</head>
-<body>
-    <?php include 'bottom_nav.php'; ?>
-
     <main>
         <h1>Statistiken</h1>
 

--- a/public/driver/umsatz_erfassen.php
+++ b/public/driver/umsatz_erfassen.php
@@ -118,15 +118,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = "Fehler: " . $e->getMessage();
     }
 }
-?>
 
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>Umsatz erfassen | DRIVE</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="css/driver-dashboard.css">
+$title = 'Umsatz erfassen';
+$extraCss = ['css/driver-dashboard.css'];
+include __DIR__ . '/../../includes/layout.php';
+?>
     <style>
         fieldset {
             border: 2px solid #ccc;
@@ -231,10 +227,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 			margin-top: 20px;
 		}
     </style>
-</head>
-<body>
-	<?php include 'bottom_nav.php'; ?>
-	<main>
+        <main>
 		<h1>Umsatz erfassen</h1>
 		<?php if ($error): ?>
 			<p style="color: red;"><?= htmlspecialchars($error) ?></p>

--- a/public/driver/update_entry.php
+++ b/public/driver/update_entry.php
@@ -72,18 +72,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = 'Fehler beim Aktualisieren des Eintrags: ' . $e->getMessage();
     }
 }
-?>
 
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Umsatz bearbeiten | DRIVE</title>
-    <link rel="stylesheet" href="css/driver-dashboard.css">
-</head>
-<body>
+$title = 'Umsatz bearbeiten';
+$extraCss = [
+    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css',
+    'css/driver-dashboard.css'
+];
+include __DIR__ . '/../../includes/layout.php';
+?>
     <main>
         <h1>Umsatz bearbeiten</h1>
         <?php if ($error): ?>
@@ -164,6 +160,5 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             document.getElementById('gesamtumsatz').value = total.toFixed(2);
         }
     </script>
-    <?php include 'bottom_nav.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Refactor driver-facing pages to set `$title` and load the shared `includes/layout.php`
- Remove direct `bottom_nav.php`/`driver-nav.php` includes and rely on central navigation
- Keep closing tags explicit so layout structure is consistent

## Testing
- `php -l public/driver/fahrzeug.php`
- `php -l public/driver/statistics.php`
- `php -l public/driver/umsatz_erfassen.php`
- `php -l public/driver/personal.php`
- `php -l public/driver/update_entry.php`
- `php -l public/driver/send_message.php`
- `php -l public/driver/dashboard.php`
- `php -r 'session_start(); $_SESSION["rolle"]="Fahrer"; $_SESSION["sekundarRolle"]=[]; $_SERVER["PHP_SELF"]="/dashboard.php"; include "public/nav.php";' | head -n 20` *(renders nav)*
- `cd public/driver && php -r 'session_start(); $_SESSION["rolle"]="Fahrer"; $_SESSION["user_id"]=1; $_SERVER["SCRIPT_NAME"]="send_message.php"; include "send_message.php";' | head -n 20` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b858694f48832b848ac125f78b5b4f