### PR TITLE
Use card-based conversation items in inbox

### DIFF
--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -13,15 +13,13 @@
 
     <div class="inbox-container">
         <div class="conversation-list">
-            <ul>
-                <?php foreach ($conversations as $conv): ?>
-                    <li data-other-id="<?= htmlspecialchars($conv['other_id']) ?>">
-                        <strong><?= htmlspecialchars($conv['other_name']) ?></strong><br>
-                        <span><?= htmlspecialchars($conv['subject']) ?></span><br>
-                        <span class="preview"><?= htmlspecialchars(mb_strimwidth($conv['body'], 0, 40, '…')) ?></span>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
+            <?php foreach ($conversations as $conv): ?>
+                <div class="card conversation-item" data-other-id="<?= htmlspecialchars($conv['other_id']) ?>" data-subject="<?= htmlspecialchars($conv['subject']) ?>">
+                    <strong><?= htmlspecialchars($conv['other_name']) ?></strong><br>
+                    <span><?= htmlspecialchars($conv['subject']) ?></span><br>
+                    <span class="preview"><?= htmlspecialchars(mb_strimwidth($conv['body'], 0, 40, '…')) ?></span>
+                </div>
+            <?php endforeach; ?>
         </div>
         <div class="conversation-panel" id="conversation-panel">
             <div id="conversation-content">

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -49,14 +49,16 @@
     padding: 1rem;
 }
 
-.inbox-container .conversation-list ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+
+.conversation-item {
+    width: 100%;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    cursor: pointer;
 }
 
-.inbox-container .conversation-list li + li {
-    margin-top: 0.5rem;
+.conversation-item:hover {
+    background-color: #f0f0f0;
 }
 
 .conversation-panel {

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function () {
-  var items = document.querySelectorAll('.conversation-list [data-other-id]');
+  var items = document.querySelectorAll('.conversation-item');
   var content = document.getElementById('conversation-content');
 
   function escapeHtml(str) {


### PR DESCRIPTION
## Summary
- Replace inbox conversation `<ul>/<li>` structure with individual `.card.conversation-item` divs and retain data attributes
- Style new conversation cards and hover behavior in `messages.css`
- Update JS selector to load conversations when `.conversation-item` cards are clicked

## Testing
- `php -l app/Views/messages/inbox.php`


------
https://chatgpt.com/codex/tasks/task_e_68b85b2e1c60832babd3d78305dd8fce