### PR TITLE
Add chat reply form and flex layout for messages

### DIFF
--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -32,6 +32,12 @@
                     <?php endforeach; ?>
                 <?php endif; ?>
             </div>
+            <form id="chat-form" method="post" action="/postfach.php?action=store">
+                <input type="hidden" name="recipient_id" id="chat-recipient-id">
+                <input type="hidden" name="subject" id="chat-subject">
+                <textarea name="body" id="chat-body" rows="3" placeholder="Nachricht" required></textarea>
+                <button type="submit">Senden</button>
+            </form>
         </div>
     </div>
     <?php include __DIR__ . '/../../../public/modals/message_compose.php'; ?>

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -61,11 +61,22 @@
     background-color: #f0f0f0;
 }
 
+
 .conversation-panel {
     flex: 1;
+    display: flex;
+    flex-direction: column;
     position: relative;
     padding: 1rem;
+}
+
+#conversation-content {
+    flex: 1;
     overflow-y: auto;
+}
+
+#chat-form {
+    margin-top: 1rem;
 }
 
 .conversation-panel .new-message-btn {

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -1,6 +1,10 @@
 document.addEventListener('DOMContentLoaded', function () {
   var items = document.querySelectorAll('.conversation-item');
   var content = document.getElementById('conversation-content');
+  var chatForm = document.getElementById('chat-form');
+  var recipientInput = document.getElementById('chat-recipient-id');
+  var subjectInput = document.getElementById('chat-subject');
+  var bodyInput = document.getElementById('chat-body');
 
   function escapeHtml(str) {
     return str
@@ -25,11 +29,34 @@ document.addEventListener('DOMContentLoaded', function () {
           });
           content.innerHTML = html;
         });
+      recipientInput.value = otherId;
+      subjectInput.value = item.getAttribute('data-subject');
     });
   });
 
   if (items.length > 0) {
     items[0].click();
+  }
+
+  if (chatForm) {
+    chatForm.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var formData = new FormData(chatForm);
+      fetch(chatForm.action, {
+        method: 'POST',
+        body: formData
+      })
+        .then(function (res) { return res.json(); })
+        .then(function (msg) {
+          var html = '<div class="message sent">' +
+            '<p><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>' +
+            '<p>' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>' +
+            '</div>';
+          content.insertAdjacentHTML('beforeend', html);
+          bodyInput.value = '';
+        })
+        .catch(function (err) { console.error(err); });
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- add inline chat form to inbox conversations
- style conversation panel as flex column with fixed input
- populate and submit chat form via JavaScript

## Testing
- `php -l app/Views/messages/inbox.php`
- `node --check public/js/messages.js`


------
https://chatgpt.com/codex/tasks/task_e_68b85bc9ae1c832ba41d4f07f8837766