### PR TITLE
Add desktop notifications for unread messages

### DIFF
--- a/public/api/unread_messages.php
+++ b/public/api/unread_messages.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../../includes/config.php';
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../app/Models/Message.php';
+
+use App\Models\Message;
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthenticated']);
+    exit;
+}
+
+$userId = (int) $_SESSION['user_id'];
+$messages = Message::getUnreadByUser($userId);
+
+echo json_encode(array_map(static function (array $message): array {
+    return [
+        'id' => (int) $message['id'],
+        'subject' => $message['subject'],
+        'body' => $message['body'],
+        'created_at' => $message['created_at'],
+        'sender_name' => $message['sender_name'],
+    ];
+}, $messages));

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -5,6 +5,9 @@ document.addEventListener('DOMContentLoaded', function () {
   var recipientInput = document.getElementById('chat-recipient-id');
   var subjectInput = document.getElementById('chat-subject');
   var bodyInput = document.getElementById('chat-body');
+  var notificationPollInterval = null;
+  var knownUnreadMessageIds = new Set();
+  var unreadInitialized = false;
 
   function escapeHtml(str) {
     return str
@@ -36,6 +39,91 @@ document.addEventListener('DOMContentLoaded', function () {
 
   if (items.length > 0) {
     items[0].click();
+  }
+
+  function baselineUnreadMessages(messages) {
+    messages.forEach(function (message) {
+      knownUnreadMessageIds.add(message.id);
+    });
+  }
+
+  function showDesktopNotification(message) {
+    if (!('Notification' in window)) {
+      return;
+    }
+
+    var title = 'Neue Nachricht von ' + message.sender_name;
+    var body = message.subject ? message.subject : message.body;
+
+    try {
+      new Notification(title, {
+        body: body,
+        tag: 'message-' + message.id
+      });
+    } catch (err) {
+      console.error('Fehler beim Anzeigen der Benachrichtigung:', err);
+    }
+  }
+
+  function fetchUnreadMessages(initialLoad) {
+    fetch('/api/unread_messages.php')
+      .then(function (res) {
+        if (!res.ok) {
+          throw new Error('HTTP ' + res.status);
+        }
+        return res.json();
+      })
+      .then(function (messages) {
+        if (!Array.isArray(messages)) {
+          return;
+        }
+
+        if (initialLoad && !unreadInitialized) {
+          baselineUnreadMessages(messages);
+          unreadInitialized = true;
+          return;
+        }
+
+        messages.forEach(function (message) {
+          if (knownUnreadMessageIds.has(message.id)) {
+            return;
+          }
+
+          knownUnreadMessageIds.add(message.id);
+
+          if (Notification.permission === 'granted') {
+            showDesktopNotification(message);
+          }
+        });
+      })
+      .catch(function (err) {
+        console.error('Fehler beim Abrufen ungelesener Nachrichten:', err);
+      });
+  }
+
+  function startNotificationPolling() {
+    if (notificationPollInterval !== null) {
+      return;
+    }
+
+    fetchUnreadMessages(true);
+    notificationPollInterval = setInterval(function () {
+      fetchUnreadMessages(false);
+    }, 30000);
+  }
+
+  if ('Notification' in window) {
+    if (Notification.permission === 'granted') {
+      startNotificationPolling();
+    } else if (Notification.permission !== 'denied') {
+      Notification.requestPermission().then(function (permission) {
+        if (permission === 'granted') {
+          startNotificationPolling();
+        }
+      }).catch(function (err) {
+        console.error('Benachrichtigungsberechtigung konnte nicht angefordert werden:', err);
+      });
+    }
   }
 
   if (chatForm) {


### PR DESCRIPTION
## Summary
- expose an API endpoint that returns unread inbox messages for the current user
- poll the new endpoint from the messaging UI and show Windows desktop notifications via the browser notification API

## Testing
- php -l public/api/unread_messages.php

------
https://chatgpt.com/codex/tasks/task_e_68e3aa45ea38832bb6d38369823f3047