### PR TITLE
Adjust compose message form layout

### DIFF
--- a/app/Views/messages/compose.php
+++ b/app/Views/messages/compose.php
@@ -3,8 +3,8 @@
 ?>
 <main>
     <h1>Neue Nachricht</h1>
-    <form method="post" action="/postfach.php?action=store">
-        <div>
+    <form method="post" action="/postfach.php?action=store" class="message-form">
+        <div class="form-group">
             <label for="recipient_id">Empfänger</label>
             <select id="recipient_id" name="recipient_id" required>
                 <?php foreach ($recipients as $r): ?>
@@ -12,13 +12,13 @@
                 <?php endforeach; ?>
             </select>
         </div>
-        <div>
+        <div class="form-group">
             <label for="subject">Betreff</label>
             <input type="text" id="subject" name="subject" required>
         </div>
-        <div>
+        <div class="form-group">
             <label for="body">Nachricht</label>
-            <textarea id="body" name="body" required></textarea>
+            <textarea id="body" name="body" rows="5" required></textarea>
         </div>
         <button type="submit">Senden</button>
     </form>

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -3,6 +3,31 @@
     height: 80vh;
 }
 
+.message-form {
+    max-width: 480px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.message-form .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.message-form select,
+.message-form input[type="text"],
+.message-form textarea {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.message-form textarea {
+    min-height: 7.5rem;
+    resize: vertical;
+}
+
 .messages-container .conversations {
     flex: 0 0 30%;
     max-width: 300px;


### PR DESCRIPTION
## Summary
- apply a dedicated form layout for the message composer
- ensure the textarea spans the same width as the recipient and subject fields and is at least five lines high

## Testing
- php -l app/Views/messages/compose.php

------
https://chatgpt.com/codex/tasks/task_e_68e3aa9f095c832ba5267121430b6425