### PR TITLE
Add Zentrale menu entry for central role

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -113,12 +113,12 @@ $menuEntries = [
     [
         'label' => 'Zentrale',
         'roles' => ['Zentrale'],
-        'icon' => 'bi-building',
+        'icon' => 'bi-telephone',
         'children' => [
             [
                 'label' => 'Zentralendashboard',
                 'url' => 'zentrale_dashboard.php',
-                'roles' => ['Admin', 'Mitarbeiter'],
+                'roles' => ['Zentrale'],
                 'icon' => 'bi-speedometer',
             ],
             [


### PR DESCRIPTION
## Summary
- update the Zentrale menu entry to use a telephone icon so it stands out in the navigation
- adjust the Zentralendashboard menu item so it is available to the Zentrale role

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3aba8a85c832bbae304c8374d4149