### PR TITLE
Add modal editing for central employees and filter inactive staff

### DIFF
--- a/cron/dienstplan-api.php
+++ b/cron/dienstplan-api.php
@@ -31,6 +31,7 @@ try {
         JOIN mitarbeiter_zentrale m ON dp.mitarbeiter_id = m.mitarbeiter_id
         JOIN schichten s ON dp.schicht_id = s.schicht_id
         WHERE dp.datum = :heute
+        AND m.status = 'Aktiv'
         AND NOT EXISTS (
             SELECT 1 
             FROM abwesenheiten_zentrale a
@@ -53,6 +54,7 @@ try {
         JOIN mitarbeiter_zentrale m ON a.mitarbeiter_id = m.mitarbeiter_id
         WHERE :heute BETWEEN a.startdatum AND a.enddatum
         AND a.typ = 'Krank'
+        AND m.status = 'Aktiv'
         AND NOT EXISTS (
             SELECT 1 
             FROM dienstplan dp
@@ -75,6 +77,7 @@ try {
         JOIN mitarbeiter_zentrale m ON dp.mitarbeiter_id = m.mitarbeiter_id
         JOIN schichten s ON dp.schicht_id = s.schicht_id
         WHERE dp.datum BETWEEN :monat_start AND :monat_ende
+        AND m.status = 'Aktiv'
         AND NOT EXISTS (
             SELECT 1 
             FROM abwesenheiten_zentrale a
@@ -99,6 +102,7 @@ try {
         JOIN mitarbeiter_zentrale m ON dp.mitarbeiter_id = m.mitarbeiter_id
         JOIN schichten s ON dp.schicht_id = s.schicht_id
         WHERE dp.datum BETWEEN :monat_start AND :monat_ende
+        AND m.status = 'Aktiv'
         AND NOT EXISTS (
             SELECT 1 
             FROM abwesenheiten_zentrale a
@@ -121,6 +125,7 @@ try {
         JOIN mitarbeiter_zentrale m ON a.mitarbeiter_id = m.mitarbeiter_id
         WHERE a.startdatum BETWEEN :monat_start AND :monat_ende
         AND a.typ = 'Urlaub'
+        AND m.status = 'Aktiv'
     ");
     $stmt->execute(['monat_start' => $aktuellerMonatStart, 'monat_ende' => $aktuellerMonatEnde]);
     $urlaubeAktuellerMonat = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -136,6 +141,7 @@ try {
         JOIN mitarbeiter_zentrale m ON a.mitarbeiter_id = m.mitarbeiter_id
         WHERE a.startdatum BETWEEN :monat_start AND :monat_ende
         AND a.typ = 'Urlaub'
+        AND m.status = 'Aktiv'
     ");
     $stmt->execute(['monat_start' => $naechsterMonatStart, 'monat_ende' => $naechsterMonatEnde]);
     $urlaubeNaechsterMonat = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/public/api/mitarbeiter_zentrale.php
+++ b/public/api/mitarbeiter_zentrale.php
@@ -1,0 +1,196 @@
+<?php
+require_once __DIR__ . '/../../includes/bootstrap.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        handleGetRequest($pdo);
+        exit;
+    }
+
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        handlePostRequest($pdo);
+        exit;
+    }
+
+    http_response_code(405);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Methode nicht erlaubt.'
+    ]);
+} catch (Throwable $exception) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Ein unerwarteter Fehler ist aufgetreten.'
+    ]);
+}
+
+function handleGetRequest(PDO $pdo): void
+{
+    $mitarbeiterId = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+    if (!$mitarbeiterId) {
+        http_response_code(400);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Eine gültige Mitarbeiter-ID ist erforderlich.'
+        ]);
+        return;
+    }
+
+    $stmt = $pdo->prepare('SELECT * FROM mitarbeiter_zentrale WHERE mitarbeiter_id = :mitarbeiter_id LIMIT 1');
+    $stmt->execute(['mitarbeiter_id' => $mitarbeiterId]);
+    $mitarbeiter = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$mitarbeiter) {
+        http_response_code(404);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Der Mitarbeiter wurde nicht gefunden.'
+        ]);
+        return;
+    }
+
+    $schema = array_values(getMitarbeiterSchema($pdo));
+
+    echo json_encode([
+        'success' => true,
+        'data' => $mitarbeiter,
+        'schema' => $schema
+    ]);
+}
+
+function handlePostRequest(PDO $pdo): void
+{
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($input)) {
+        $input = $_POST;
+    }
+
+    if (!isset($input['mitarbeiter_id'])) {
+        http_response_code(400);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Die Mitarbeiter-ID fehlt.'
+        ]);
+        return;
+    }
+
+    $mitarbeiterId = filter_var($input['mitarbeiter_id'], FILTER_VALIDATE_INT);
+    if (!$mitarbeiterId) {
+        http_response_code(400);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Die Mitarbeiter-ID ist ungültig.'
+        ]);
+        return;
+    }
+
+    $schema = getMitarbeiterSchema($pdo);
+    $allowedColumns = array_keys($schema);
+    $allowedColumns = array_diff($allowedColumns, ['mitarbeiter_id']);
+
+    $fieldsToUpdate = [];
+    $params = ['mitarbeiter_id' => $mitarbeiterId];
+
+    foreach ($input as $column => $value) {
+        if ($column === 'mitarbeiter_id' || !in_array($column, $allowedColumns, true)) {
+            continue;
+        }
+
+        $columnMeta = $schema[$column];
+        $value = normalizeValue($value, $columnMeta);
+
+        if ($column === 'status' && !in_array($value, ['Aktiv', 'Inaktiv'], true)) {
+            http_response_code(422);
+            echo json_encode([
+                'success' => false,
+                'message' => 'Der Status muss entweder "Aktiv" oder "Inaktiv" sein.'
+            ]);
+            return;
+        }
+
+        if (in_array($column, ['vorname', 'nachname'], true) && (!is_string($value) || trim($value) === '')) {
+            http_response_code(422);
+            echo json_encode([
+                'success' => false,
+                'message' => 'Vorname und Nachname dürfen nicht leer sein.'
+            ]);
+            return;
+        }
+
+        $fieldsToUpdate[] = sprintf('`%s` = :%s', $column, $column);
+        $params[$column] = $value;
+    }
+
+    if (empty($fieldsToUpdate)) {
+        echo json_encode([
+            'success' => true,
+            'message' => 'Es wurden keine Änderungen erkannt.'
+        ]);
+        return;
+    }
+
+    $sql = sprintf(
+        'UPDATE mitarbeiter_zentrale SET %s WHERE mitarbeiter_id = :mitarbeiter_id',
+        implode(', ', $fieldsToUpdate)
+    );
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+
+    echo json_encode([
+        'success' => true,
+        'message' => 'Der Mitarbeiter wurde erfolgreich aktualisiert.'
+    ]);
+}
+
+function getMitarbeiterSchema(PDO $pdo): array
+{
+    static $schemaCache = null;
+    if ($schemaCache !== null) {
+        return $schemaCache;
+    }
+
+    $stmt = $pdo->query('DESCRIBE mitarbeiter_zentrale');
+    $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $schemaCache = [];
+    foreach ($columns as $column) {
+        $schemaCache[$column['Field']] = $column;
+    }
+
+    return $schemaCache;
+}
+
+function normalizeValue($value, array $columnMeta)
+{
+    $type = strtolower($columnMeta['Type'] ?? '');
+    $allowsNull = strtoupper($columnMeta['Null'] ?? '') === 'YES';
+
+    if ($value === '' && $allowsNull) {
+        return null;
+    }
+
+    if (is_string($value)) {
+        $value = trim($value);
+    }
+
+    if (strpos($type, 'int') !== false) {
+        return $value === null ? null : (int) $value;
+    }
+
+    if (strpos($type, 'decimal') !== false || strpos($type, 'double') !== false || strpos($type, 'float') !== false) {
+        return $value === null ? null : (float) $value;
+    }
+
+    if (strpos($type, 'tinyint(1)') !== false || strpos($type, 'bool') !== false) {
+        if ($value === null) {
+            return null;
+        }
+        return $value === '' ? null : (int) $value;
+    }
+
+    return $value;
+}

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -546,6 +546,15 @@ input:focus, select:focus {
   color: var(--color-primary-dark);
 }
 
+.dashboard-table tbody tr.mitarbeiter-row {
+  cursor: pointer;
+  transition: background-color var(--transition-speed, 0.2s) ease-in-out;
+}
+
+.dashboard-table tbody tr.mitarbeiter-row:hover {
+  background-color: rgba(13, 110, 253, 0.08);
+}
+
 /*********************************************
  * SIDEBAR
  *********************************************/

--- a/public/dienstplan_erstellung.php
+++ b/public/dienstplan_erstellung.php
@@ -23,7 +23,7 @@ setlocale(LC_TIME, 'de_DE.UTF-8');
 $currentMonthName = date('F Y', strtotime($start_date));
 
 // Mitarbeiter abrufen
-$stmt = $pdo->query("SELECT mitarbeiter_id, vorname, nachname FROM mitarbeiter_zentrale ORDER BY nachname ASC");
+$stmt = $pdo->query("SELECT mitarbeiter_id, vorname, nachname FROM mitarbeiter_zentrale WHERE status = 'Aktiv' ORDER BY nachname ASC");
 $mitarbeiterListe = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // Schichten abrufen

--- a/public/js/mitarbeiter_zentrale.js
+++ b/public/js/mitarbeiter_zentrale.js
@@ -1,0 +1,277 @@
+(function () {
+  const modalId = 'mitarbeiterEditModal';
+  const form = document.getElementById('mitarbeiterEditForm');
+  const formFieldsContainer = document.getElementById('mitarbeiterFormFields');
+  const formMessages = document.getElementById('mitarbeiterFormMessages');
+  const hiddenIdField = document.getElementById('mitarbeiterEditId');
+  const employeeRows = document.querySelectorAll('.dashboard-table tbody tr.mitarbeiter-row');
+
+  if (!form || !formFieldsContainer || !hiddenIdField) {
+    return;
+  }
+
+  const READONLY_FIELDS = new Set(['mitarbeiter_id', 'created_at', 'updated_at', 'erstellt_am', 'angelegt_am']);
+
+  const STATUS_OPTIONS = [
+    { value: 'Aktiv', label: 'Aktiv' },
+    { value: 'Inaktiv', label: 'Inaktiv' }
+  ];
+
+  const BOOLEAN_OPTIONS = [
+    { value: '1', label: 'Ja' },
+    { value: '0', label: 'Nein' }
+  ];
+
+  employeeRows.forEach((row) => {
+    row.addEventListener('dblclick', () => {
+      const id = row.dataset.mitarbeiterId;
+      if (!id) {
+        return;
+      }
+      loadEmployee(id);
+    });
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!hiddenIdField.value) {
+      return;
+    }
+
+    clearMessage();
+    setSubmitting(true);
+
+    try {
+      const formData = new FormData(form);
+      const payload = {};
+      formData.forEach((value, key) => {
+        payload[key] = value;
+      });
+
+      const response = await fetch('api/mitarbeiter_zentrale.php', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      const result = await response.json().catch(() => null);
+      if (!response.ok || !result || !result.success) {
+        const message = (result && result.message) || 'Die Änderungen konnten nicht gespeichert werden.';
+        showMessage('danger', message);
+        setSubmitting(false);
+        return;
+      }
+
+      showMessage('success', result.message || 'Die Änderungen wurden gespeichert.');
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
+    } catch (error) {
+      showMessage('danger', 'Beim Speichern ist ein Fehler aufgetreten.');
+      setSubmitting(false);
+    }
+  });
+
+  async function loadEmployee(id) {
+    clearMessage();
+    setFormDisabled(true);
+    hiddenIdField.value = '';
+    formFieldsContainer.innerHTML = '<p class="text-muted">Daten werden geladen …</p>';
+
+    try {
+      const response = await fetch(`api/mitarbeiter_zentrale.php?id=${encodeURIComponent(id)}`, {
+        headers: {
+          Accept: 'application/json'
+        }
+      });
+
+      const result = await response.json().catch(() => null);
+      if (!response.ok || !result || !result.success) {
+        const message = (result && result.message) || 'Die Mitarbeiterdaten konnten nicht geladen werden.';
+        formFieldsContainer.innerHTML = '';
+        showMessage('danger', message);
+        setFormDisabled(false);
+        return;
+      }
+
+      renderForm(result.data, result.schema || []);
+      hiddenIdField.value = result.data.mitarbeiter_id;
+      setFormDisabled(false);
+      openModal(modalId);
+    } catch (error) {
+      formFieldsContainer.innerHTML = '';
+      showMessage('danger', 'Beim Laden der Mitarbeiterdaten ist ein Fehler aufgetreten.');
+      setFormDisabled(false);
+    }
+  }
+
+  function renderForm(data, schema) {
+    const schemaMap = Array.isArray(schema)
+      ? schema.reduce((accumulator, column) => {
+          if (column && (column.Field || column.field)) {
+            accumulator[column.Field || column.field] = column;
+          }
+          return accumulator;
+        }, {})
+      : {};
+
+    formFieldsContainer.innerHTML = '';
+
+    Object.entries(data || {}).forEach(([key, value]) => {
+      if (READONLY_FIELDS.has(key)) {
+        return;
+      }
+
+      const normalizedKey = key.toLowerCase();
+      const column = schemaMap[key] || {};
+      const columnType = (column.Type || column.type || '').toLowerCase();
+      const isNullable = (column.Null || column.nullable || '').toUpperCase() === 'YES';
+      const labelText = column.Comment || humanizeKey(key);
+
+      const formGroup = document.createElement('div');
+      formGroup.className = 'col-12 col-md-6';
+
+      const label = document.createElement('label');
+      label.className = 'form-label';
+      label.setAttribute('for', `mitarbeiter_${key}`);
+      label.textContent = labelText;
+
+      const inputWrapper = document.createElement('div');
+      inputWrapper.appendChild(label);
+
+      const inputElement = createInputElement({
+        key,
+        value,
+        columnType,
+        isNullable,
+        normalizedKey
+      });
+
+      inputWrapper.appendChild(inputElement);
+      formGroup.appendChild(inputWrapper);
+      formFieldsContainer.appendChild(formGroup);
+    });
+  }
+
+  function createInputElement({ key, value, columnType, isNullable, normalizedKey }) {
+    let element;
+
+    if (key === 'status') {
+      element = document.createElement('select');
+      element.className = 'form-select';
+      STATUS_OPTIONS.forEach((option) => {
+        const optionElement = document.createElement('option');
+        optionElement.value = option.value;
+        optionElement.textContent = option.label;
+        if (String(value || '') === option.value) {
+          optionElement.selected = true;
+        }
+        element.appendChild(optionElement);
+      });
+    } else if (/tinyint\(1\)|bool|boolean/.test(columnType)) {
+      element = document.createElement('select');
+      element.className = 'form-select';
+      const currentValue = value == null ? '' : String(value);
+      const options = [...BOOLEAN_OPTIONS];
+      if (isNullable) {
+        options.unshift({ value: '', label: 'Nicht gesetzt' });
+      }
+      options.forEach((option) => {
+        const optionElement = document.createElement('option');
+        optionElement.value = option.value;
+        optionElement.textContent = option.label;
+        if (currentValue === option.value) {
+          optionElement.selected = true;
+        }
+        element.appendChild(optionElement);
+      });
+    } else if (/text/.test(columnType) || /beschreibung|notiz|kommentar/.test(normalizedKey)) {
+      element = document.createElement('textarea');
+      element.className = 'form-control';
+      element.rows = 3;
+      element.value = value == null ? '' : value;
+    } else {
+      element = document.createElement('input');
+      element.className = 'form-control';
+      element.value = value == null ? '' : value;
+
+      if (/int|decimal|double|float/.test(columnType)) {
+        element.type = 'number';
+        if (/decimal|double|float/.test(columnType)) {
+          element.step = '0.01';
+        }
+      } else if (/date/.test(columnType)) {
+        element.type = 'date';
+      } else if (/time/.test(columnType)) {
+        element.type = 'time';
+      } else if (normalizedKey.includes('email')) {
+        element.type = 'email';
+      } else if (normalizedKey.includes('telefon') || normalizedKey.includes('phone')) {
+        element.type = 'tel';
+      } else if (normalizedKey.includes('farbe')) {
+        element.type = 'color';
+      } else {
+        element.type = 'text';
+      }
+    }
+
+    element.id = `mitarbeiter_${key}`;
+    element.name = key;
+    if (!isNullable) {
+      element.required = true;
+    }
+
+    if (element instanceof HTMLInputElement && element.type === 'date' && value) {
+      element.value = value;
+    }
+
+    if (element instanceof HTMLInputElement && element.type === 'number' && value !== null && value !== undefined && value !== '') {
+      element.value = String(value);
+    }
+
+    return element;
+  }
+
+  function humanizeKey(key) {
+    return key
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  }
+
+  function clearMessage() {
+    if (!formMessages) {
+      return;
+    }
+    formMessages.textContent = '';
+    formMessages.classList.add('d-none');
+    formMessages.classList.remove('alert-success', 'alert-danger');
+  }
+
+  function showMessage(type, message) {
+    if (!formMessages) {
+      return;
+    }
+    formMessages.textContent = message;
+    formMessages.classList.remove('d-none', 'alert-success', 'alert-danger');
+    formMessages.classList.add(type === 'success' ? 'alert-success' : 'alert-danger', 'alert');
+  }
+
+  function setSubmitting(isSubmitting) {
+    const submitButton = form.querySelector('button[type="submit"]');
+    if (!submitButton) {
+      return;
+    }
+    submitButton.disabled = isSubmitting;
+    submitButton.dataset.originalText = submitButton.dataset.originalText || submitButton.textContent;
+    submitButton.textContent = isSubmitting ? 'Speichern …' : submitButton.dataset.originalText;
+  }
+
+  function setFormDisabled(isDisabled) {
+    Array.from(form.elements).forEach((element) => {
+      element.disabled = isDisabled && element.type !== 'hidden';
+    });
+  }
+})();

--- a/public/modals/add_abwesenheit_modal.php
+++ b/public/modals/add_abwesenheit_modal.php
@@ -5,7 +5,7 @@ require_once '../includes/db.php'; // Datenbankverbindung
 
 // Mitarbeiter abrufen
 try {
-    $stmtMitarbeiter = $pdo->query("SELECT mitarbeiter_id, CONCAT(vorname, ' ', nachname) AS name FROM mitarbeiter_zentrale ORDER BY nachname ASC");
+    $stmtMitarbeiter = $pdo->query("SELECT mitarbeiter_id, CONCAT(vorname, ' ', nachname) AS name FROM mitarbeiter_zentrale WHERE status = 'Aktiv' ORDER BY nachname ASC");
     $mitarbeiter = $stmtMitarbeiter->fetchAll(PDO::FETCH_ASSOC);
 } catch (PDOException $e) {
     die('Fehler beim Abrufen der Mitarbeiter: ' . $e->getMessage());

--- a/public/modals/process_abwesenheit.php
+++ b/public/modals/process_abwesenheit.php
@@ -24,6 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_abwesenheit'])) {
             SELECT vorname, nachname
             FROM mitarbeiter_zentrale
             WHERE mitarbeiter_id = ?
+              AND status = 'Aktiv'
             LIMIT 1
         ");
         $stmtMitarbeiter->execute([$mitarbeiter_id]);


### PR DESCRIPTION
## Summary
- add a dynamic modal editor and supporting API so double-clicking a central employee opens all editable fields
- filter inactive central employees out of dashboards, schedules, modals, and cron data sources
- polish UI feedback for clickable employee rows and ensure absence handling only targets active staff

## Testing
- php -l public/zentrale_dashboard.php
- php -l public/dashboard.php
- php -l public/dienstplan_erstellung.php
- php -l public/modals/add_abwesenheit_modal.php
- php -l public/modals/process_abwesenheit.php
- php -l cron/dienstplan-api.php
- php -l public/api/mitarbeiter_zentrale.php


------
https://chatgpt.com/codex/tasks/task_e_68e3adb6e5cc832b84b8e14cfe22bef7