### PR TITLE
Show inbox message subjects and read timestamps

### DIFF
--- a/app/Controllers/MessageController.php
+++ b/app/Controllers/MessageController.php
@@ -33,6 +33,7 @@ class MessageController
         }
 
         $userId = (int) $_SESSION['user_id'];
+        Message::markConversationAsRead($userId, $otherId);
         $messages = Message::getMessagesBetween($userId, $otherId);
         $title = 'Nachrichtenverlauf';
         $extraCss = 'css/messages.css';
@@ -54,11 +55,13 @@ class MessageController
         $conversation = [];
         if (isset($_GET['with'])) {
             $otherId = (int) $_GET['with'];
+            Message::markConversationAsRead($userId, $otherId);
             $conversation = Message::getMessagesBetween($userId, $otherId);
         }
         $success = ($_GET['success'] ?? '') !== '';
         $title = 'Postfach';
         $extraCss = 'css/messages.css';
+        $currentUserId = $userId;
         include __DIR__ . '/../../includes/layout.php';
         include __DIR__ . '/../Views/messages/inbox.php';
         echo "</body></html>";

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -56,7 +56,7 @@ class Message
     {
         global $pdo;
         $stmt = $pdo->prepare('
-            SELECT m.id, m.subject, m.body, m.created_at,
+            SELECT m.id, m.subject, m.body, m.created_at, m.read_at,
                    m.sender_id, m.recipient_id,
                    sender.Name AS sender_name,
                    recipient.Name AS recipient_name
@@ -69,5 +69,12 @@ class Message
         ');
         $stmt->execute(['uid' => $userId, 'oid' => $otherId]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public static function markConversationAsRead(int $userId, int $otherId): void
+    {
+        global $pdo;
+        $stmt = $pdo->prepare('UPDATE messages SET read_at = NOW() WHERE recipient_id = ? AND sender_id = ? AND read_at IS NULL');
+        $stmt->execute([$userId, $otherId]);
     }
 }

--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -25,9 +25,16 @@
             <div id="conversation-content">
                 <?php if (!empty($conversation)): ?>
                     <?php foreach ($conversation as $msg): ?>
-                        <div class="message">
-                            <p><strong><?= htmlspecialchars($msg['sender_name']) ?></strong> am <?= htmlspecialchars($msg['created_at']) ?></p>
-                            <p><?= nl2br(htmlspecialchars($msg['body'])) ?></p>
+                        <?php $isSent = isset($currentUserId) && (int) $msg['sender_id'] === (int) $currentUserId; ?>
+                        <div class="message <?= $isSent ? 'sent' : 'received' ?>">
+                            <p class="message-header"><strong><?= htmlspecialchars($msg['sender_name']) ?></strong> am <?= htmlspecialchars($msg['created_at']) ?></p>
+                            <?php if (!empty($msg['subject'])): ?>
+                                <p class="message-subject"><span>Betreff:</span> <?= htmlspecialchars($msg['subject']) ?></p>
+                            <?php endif; ?>
+                            <p class="message-body"><?= nl2br(htmlspecialchars($msg['body'])) ?></p>
+                            <?php if (!empty($msg['read_at'])): ?>
+                                <p class="message-meta">Gelesen am <?= htmlspecialchars($msg['read_at']) ?></p>
+                            <?php endif; ?>
                         </div>
                     <?php endforeach; ?>
                 <?php endif; ?>

--- a/public/api/messages.php
+++ b/public/api/messages.php
@@ -21,6 +21,7 @@ if ($otherId === 0) {
 }
 
 $userId = (int) $_SESSION['user_id'];
+Message::markConversationAsRead($userId, $otherId);
 $messages = Message::getMessagesBetween($userId, $otherId);
 echo json_encode($messages);
 

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -114,6 +114,7 @@
     padding: 0.5rem 0.75rem;
     border-radius: 0.5rem;
     max-width: 75%;
+    width: fit-content;
 }
 
 .message.sent {
@@ -126,5 +127,27 @@
     background-color: #ffffff;
     border: 1px solid #ccc;
     margin-right: auto;
+}
+
+.message-header {
+    margin: 0 0 0.25rem 0;
+}
+
+.message-subject {
+    margin: 0 0 0.25rem 0;
+}
+
+.message-subject span {
+    font-weight: 600;
+}
+
+.message-body {
+    margin: 0;
+}
+
+.message-meta {
+    margin: 0.25rem 0 0 0;
+    font-size: 0.75rem;
+    color: #666;
 }
 

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -25,10 +25,16 @@ document.addEventListener('DOMContentLoaded', function () {
           var html = '';
           messages.forEach(function (msg) {
             var cls = (msg.sender_id === otherId) ? 'received' : 'sent';
-            html += '<div class="message ' + cls + '">' +
-              '<p><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>' +
-              '<p>' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>' +
-              '</div>';
+            html += '<div class="message ' + cls + '">';
+            html += '<p class="message-header"><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>';
+            if (msg.subject) {
+              html += '<p class="message-subject"><span>Betreff:</span> ' + escapeHtml(msg.subject) + '</p>';
+            }
+            html += '<p class="message-body">' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>';
+            if (msg.read_at) {
+              html += '<p class="message-meta">Gelesen am ' + escapeHtml(msg.read_at) + '</p>';
+            }
+            html += '</div>';
           });
           content.innerHTML = html;
         });
@@ -136,11 +142,19 @@ document.addEventListener('DOMContentLoaded', function () {
       })
         .then(function (res) { return res.json(); })
         .then(function (msg) {
-          var html = '<div class="message sent">' +
-            '<p><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>' +
-            '<p>' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>' +
-            '</div>';
-          content.insertAdjacentHTML('beforeend', html);
+          if (msg && msg.sender_name) {
+            var newMessageHtml = '<div class="message sent">';
+            newMessageHtml += '<p class="message-header"><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>';
+            if (msg.subject) {
+              newMessageHtml += '<p class="message-subject"><span>Betreff:</span> ' + escapeHtml(msg.subject) + '</p>';
+            }
+            newMessageHtml += '<p class="message-body">' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>';
+            if (msg.read_at) {
+              newMessageHtml += '<p class="message-meta">Gelesen am ' + escapeHtml(msg.read_at) + '</p>';
+            }
+            newMessageHtml += '</div>';
+            content.insertAdjacentHTML('beforeend', newMessageHtml);
+          }
           bodyInput.value = '';
         })
         .catch(function (err) { console.error(err); });

--- a/public/postfach.php
+++ b/public/postfach.php
@@ -58,6 +58,7 @@ if ($isDriver) {
 $recipients = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $extraCss = 'css/messages.css';
+$currentUserId = $userId;
 
 if ($action === 'compose') {
     $title = 'Neue Nachricht';
@@ -68,6 +69,7 @@ if ($action === 'compose') {
     $conversation = [];
     if (isset($_GET['with'])) {
         $otherId = (int) $_GET['with'];
+        Message::markConversationAsRead($userId, $otherId);
         $conversation = Message::getMessagesBetween($userId, $otherId);
     }
     $success = ($_GET['success'] ?? '') !== '';


### PR DESCRIPTION
## Summary
- display each message's subject and read timestamp in the inbox view and client rendering
- mark conversations as read when opened through controllers or the API so `read_at` is persisted
- adjust message bubble styling to size to its content while keeping the current maximum width

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3ae955734832ba7af561e033cbcb5