### PR TITLE
Fix HTTP 500 when approving admin absences

### DIFF
--- a/public/verwaltung_abwesenheit_status.php
+++ b/public/verwaltung_abwesenheit_status.php
@@ -5,7 +5,12 @@ if (!isLoggedIn()) {
     die("Nicht eingeloggt.");
 }
 
-$rollen = array_map('trim', explode(',', $sekundarRolle ?? ''));
+$rollenQuelle = $sekundarRolle ?? '';
+if (is_array($rollenQuelle)) {
+    $rollen = array_map('trim', $rollenQuelle);
+} else {
+    $rollen = array_map('trim', explode(',', (string) $rollenQuelle));
+}
 if (!in_array('Verwaltung', $rollen, true)) {
     die("Keine Berechtigung.");
 }


### PR DESCRIPTION
## Summary
- handle secondary roles that are already stored as arrays when checking for administration permission
- preserve string-based role parsing as a fallback to keep existing behavior

## Testing
- php -l public/verwaltung_abwesenheit_status.php

------
https://chatgpt.com/codex/tasks/task_e_68e3af07b168832bbd47e558b934c54e