### PR TITLE
Redesign dashboard layout and styling

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1100,3 +1100,358 @@ button:hover {
 
 /* Falls du noch weitere Texte o. Ä. animieren möchtest, könntest du solche Keyframes
    einsetzen oder eigene erstellen (z.B. Slide-In, Fade-In, Shake, etc.). */
+
+/*********************************************
+ * DASHBOARD REDESIGN
+ *********************************************/
+.dashboard-container {
+    max-width: 1200px;
+}
+
+.dashboard-hero {
+    border: none;
+    border-radius: 1.75rem;
+    background: linear-gradient(135deg, rgba(255, 214, 0, 0.35), rgba(255, 214, 0, 0.05));
+    position: relative;
+    overflow: hidden;
+}
+
+.dashboard-hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(255, 214, 0, 0.55), transparent 55%);
+    opacity: 0.85;
+}
+
+.dashboard-hero .card-body {
+    position: relative;
+    z-index: 1;
+    padding: 2.75rem;
+}
+
+.hero-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #a07c00;
+    margin-bottom: 0.75rem;
+}
+
+.hero-title {
+    font-size: clamp(2.2rem, 2.4vw + 1.2rem, 3.4rem);
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: #1f1f1f;
+}
+
+.hero-subtitle {
+    font-size: 1.05rem;
+    color: #4d4d4d;
+    margin: 0;
+    max-width: 36rem;
+}
+
+.hero-meta {
+    margin-top: 1.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.hero-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.55rem 1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.7);
+    color: #343a40;
+    font-weight: 600;
+}
+
+.hero-meta-badge {
+    background: rgba(33, 33, 33, 0.12);
+}
+
+.dashboard-quickstats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+    margin: 2rem 0 2.5rem;
+}
+
+.stat-card {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-radius: 1.25rem;
+    background: #ffffff;
+    border: 1px solid #f1f3f5;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.06);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 28px 55px rgba(15, 23, 42, 0.1);
+}
+
+.stat-icon {
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: 0.9rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.6rem;
+}
+
+.stat-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.stat-label {
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    letter-spacing: 0.16em;
+    color: #6c757d;
+    font-weight: 600;
+}
+
+.stat-value {
+    font-size: 1.85rem;
+    font-weight: 700;
+    color: #212529;
+}
+
+.dashboard-main {
+    display: grid;
+    gap: 1.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+}
+
+@media (min-width: 992px) {
+    .grid-span-2 {
+        grid-column: span 2;
+    }
+}
+
+@media (min-width: 1200px) {
+    .grid-span-full {
+        grid-column: 1 / -1;
+    }
+}
+
+.widget.card {
+    border: none;
+    border-radius: 1.5rem;
+    background: #ffffff;
+    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.05);
+}
+
+.widget.card .card-body {
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.section-title {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin: 0;
+    color: #1f1f1f;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.section-title i {
+    color: #c29c00;
+}
+
+.section-subtitle {
+    margin: 0;
+    color: #6c757d;
+    font-size: 0.95rem;
+}
+
+.company-card {
+    background: #fdfdfd;
+    border: 1px solid #eef1f4;
+    border-radius: 1rem;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.company-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.company-title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #1f1f1f;
+}
+
+.two-column {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.info-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.info-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #1f1f1f;
+}
+
+.stacked-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+}
+
+.stacked-list-item {
+    background: #f9fafb;
+    border: 1px solid #edf0f3;
+    border-radius: 1rem;
+    padding: 1rem 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stacked-list-item:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+}
+
+.list-primary {
+    font-weight: 600;
+    color: #1f1f1f;
+}
+
+.list-secondary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.9rem;
+    color: #495057;
+}
+
+.list-secondary span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.list-meta {
+    font-size: 0.82rem;
+    color: #6c757d;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.dashboard-table thead th {
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    background: #f8f9fa;
+    border-bottom: 2px solid #e9ecef;
+}
+
+.dashboard-table tbody th {
+    font-weight: 600;
+    color: #1f1f1f;
+}
+
+.dashboard-table td,
+.dashboard-table th {
+    white-space: nowrap;
+}
+
+.dashboard-table .weekend {
+    background: rgba(220, 53, 69, 0.12);
+    color: #a11a2b;
+}
+
+.dashboard-table .early-shift {
+    background: rgba(25, 135, 84, 0.18);
+    color: #0f5132;
+}
+
+.dashboard-table .mid-shift {
+    background: rgba(255, 193, 7, 0.18);
+    color: #664d03;
+}
+
+.dashboard-table .late-shift {
+    background: rgba(13, 110, 253, 0.12);
+    color: #0a58ca;
+}
+
+.dashboard-table .night-shift {
+    background: rgba(108, 117, 125, 0.16);
+    color: #495057;
+}
+
+@media (max-width: 768px) {
+    .dashboard-hero .card-body {
+        padding: 2rem;
+    }
+
+    .dashboard-quickstats {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+    }
+
+    .stat-card {
+        padding: 1.25rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .hero-meta span {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .dashboard-quickstats {
+        grid-template-columns: 1fr;
+    }
+}

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -29,7 +29,6 @@ $greetings = [
     "Was für ein schöner Tag, "
 ];
 
-
 $greeting_message = $greetings[array_rand($greetings)] . htmlspecialchars($user_name) . "!";
 
 // Dynamische Dashboard-Titel erstellen
@@ -48,10 +47,9 @@ $dashboardTitles = [
 
 $subtitle_message = $dashboardTitles[array_rand($dashboardTitles)];
 
-
 // Zeitraum für Dienstplan: Morgen + 5 Tage
 $start_date = date('Y-m-d', strtotime('+1 day'));
-$end_date = date('Y-m-d', strtotime('+6 days'));
+$end_date   = date('Y-m-d', strtotime('+6 days'));
 
 // Mitarbeiter abrufen
 $stmt = $pdo->prepare("SELECT vorname, nachname, mitarbeiter_id FROM mitarbeiter_zentrale WHERE status = 'Aktiv' ORDER BY nachname ASC");
@@ -62,17 +60,17 @@ $mitarbeiter = $stmt->fetchAll(PDO::FETCH_ASSOC);
 $dates = [];
 for ($date = strtotime($start_date); $date <= strtotime($end_date); $date = strtotime('+1 day', $date)) {
     $dates[] = [
-        'day' => date('d.m.', $date),
+        'day'       => date('d.m.', $date),
         'isWeekend' => in_array(date('N', $date), [6, 7]), // Samstag oder Sonntag
-        'date' => date('Y-m-d', $date),
+        'date'      => date('Y-m-d', $date),
     ];
 }
 
 // Schichten aus dem Dienstplan abrufen
 $stmt = $pdo->prepare(
-    "SELECT dp.mitarbeiter_id, dp.datum, s.name AS schicht_name 
-     FROM dienstplan dp 
-     LEFT JOIN schichten s ON dp.schicht_id = s.schicht_id 
+    "SELECT dp.mitarbeiter_id, dp.datum, s.name AS schicht_name
+     FROM dienstplan dp
+     LEFT JOIN schichten s ON dp.schicht_id = s.schicht_id
      WHERE dp.datum BETWEEN :start_date AND :end_date"
 );
 $stmt->execute(['start_date' => $start_date, 'end_date' => $end_date]);
@@ -83,408 +81,574 @@ $dienstplanMap = [];
 foreach ($dienstplan as $entry) {
     $dienstplanMap[$entry['mitarbeiter_id']][$entry['datum']] = $entry['schicht_name'];
 }
-?>
-<?php
+
+// Datumstext für den Header
+$daysOfWeek = [
+    'Monday'    => 'Montag',
+    'Tuesday'   => 'Dienstag',
+    'Wednesday' => 'Mittwoch',
+    'Thursday'  => 'Donnerstag',
+    'Friday'    => 'Freitag',
+    'Saturday'  => 'Samstag',
+    'Sunday'    => 'Sonntag',
+];
+$todayLabel = ($daysOfWeek[date('l')] ?? date('l')) . ', ' . date('d.m.Y');
+
+// Aktive Fahrer strukturieren
+$activeDriversByCompany = [];
+$activeDriversError     = null;
+try {
+    $stmt = $pdo->prepare(
+        "SELECT
+            sfa.unternehmer AS firmenname,
+            COALESCE(f.Vorname, 'Unbekannt') AS fahrer_vorname,
+            COALESCE(f.Nachname, '') AS fahrer_nachname,
+            COALESCE(v.Kennzeichen, 'Ersatzfahrzeug') AS kennzeichen,
+            sfa.anmeldung,
+            sfa.fahrzeugflotte
+        FROM sync_fahreranmeldung sfa
+        LEFT JOIN Fahrer f
+            ON sfa.fahrer = f.fms_alias OR sfa.fahrer = f.Fahrernummer
+        LEFT JOIN Fahrzeuge v
+            ON sfa.kennung = v.Konzessionsnummer OR sfa.kennung = v.fms_alias
+        WHERE sfa.abmeldung IS NULL
+        ORDER BY firmenname, sfa.anmeldung DESC"
+    );
+    $stmt->execute();
+    $aktive = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    foreach ($aktive as $eintrag) {
+        switch ($eintrag['firmenname']) {
+            case '720':
+                $anzeigeName = '4884 – Ihr Funktaxi';
+                break;
+            case '5810':
+                $anzeigeName = '4884 Service GbR';
+                break;
+            case '292':
+                $anzeigeName = 'Cityline GbR';
+                break;
+            default:
+                $anzeigeName = 'Unbekannter Unternehmer (' . $eintrag['firmenname'] . ')';
+        }
+        $activeDriversByCompany[$anzeigeName][] = $eintrag;
+    }
+} catch (PDOException $e) {
+    $activeDriversError = $e->getMessage();
+}
+
+$totalActiveDrivers = array_sum(array_map('count', $activeDriversByCompany));
+
+// Geburtstage
+$fahrer_birthdays = [];
+$zentrale_birthdays = [];
+$birthdaysError = null;
+try {
+    $stmt_fahrer = $pdo->prepare("SELECT CONCAT(Vorname, ' ', Nachname) AS name FROM Fahrer WHERE DATE_FORMAT(geburtsdatum, '%m-%d') = DATE_FORMAT(NOW(), '%m-%d')");
+    $stmt_fahrer->execute();
+    $fahrer_birthdays = $stmt_fahrer->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $birthdaysError = $e->getMessage();
+}
+
+try {
+    $stmt_zentrale = $pdo->prepare("SELECT CONCAT(Vorname, ' ', Nachname) AS name FROM mitarbeiter_zentrale WHERE DATE_FORMAT(geburtsdatum, '%m-%d') = DATE_FORMAT(NOW(), '%m-%d') AND status = 'Aktiv'");
+    $stmt_zentrale->execute();
+    $zentrale_birthdays = $stmt_zentrale->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $birthdaysError = $birthdaysError ? $birthdaysError . ' / ' . $e->getMessage() : $e->getMessage();
+}
+
+$birthdays      = array_merge($fahrer_birthdays, $zentrale_birthdays);
+$birthdaysCount = count($birthdays);
+
+// Wartungen heute
+$maintenancesDueToday      = [];
+$maintenancesDueTodayError = null;
+try {
+    $stmt = $pdo->prepare(
+        "SELECT DATE_FORMAT(w.Wartungsdatum, '%d.%m.%Y') AS Wartungsdatum, f.Konzessionsnummer, f.Kennzeichen, f.Marke, f.Modell
+         FROM Wartung w
+         JOIN Fahrzeuge f ON w.FahrzeugID = f.FahrzeugID
+         WHERE DATE(w.Wartungsdatum) = CURDATE()"
+    );
+    $stmt->execute();
+    $maintenancesDueToday = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $maintenancesDueTodayError = $e->getMessage();
+}
+$maintenancesDueTodayCount = count($maintenancesDueToday);
+
+// Wartungstermine in den nächsten drei Monaten
+$upcomingMaintenances      = [];
+$upcomingMaintenancesError = null;
+try {
+    $stmt = $pdo->prepare(
+        "SELECT DATE_FORMAT(w.Wartungsdatum, '%d.%m.%Y') AS FormattedDate, w.Werkstatt, f.Konzessionsnummer, f.Marke, f.Modell
+         FROM Wartung w
+         JOIN Fahrzeuge f ON w.FahrzeugID = f.FahrzeugID
+         WHERE w.Wartungsdatum BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 3 MONTH)
+         ORDER BY w.Wartungsdatum ASC"
+    );
+    $stmt->execute();
+    $upcomingMaintenances = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $upcomingMaintenancesError = $e->getMessage();
+}
+
+// Fällige TÜV
+$huDue    = [];
+$huDueError = null;
+try {
+    $stmt = $pdo->prepare("SELECT Konzessionsnummer, Marke, Modell, DATE_FORMAT(HU, '%d.%m.%Y') AS HU FROM Fahrzeuge WHERE HU BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 3 MONTH) ORDER BY HU ASC");
+    $stmt->execute();
+    $huDue = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $huDueError = $e->getMessage();
+}
+
+// P-Schein Gültigkeit
+$pscheinDue  = [];
+$pscheinError = null;
+try {
+    $stmt = $pdo->prepare("SELECT CONCAT(Vorname, ' ', Nachname) AS Name, DATE_FORMAT(PScheinGueltigkeit, '%d.%m.%Y') AS PScheinGueltigkeit FROM Fahrer WHERE PScheinGueltigkeit BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 3 MONTH) ORDER BY PScheinGueltigkeit ASC");
+    $stmt->execute();
+    $pscheinDue = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $pscheinError = $e->getMessage();
+}
+
+// Abwesenheiten
+$fahrerAbsences      = [];
+$fahrerAbsencesError = null;
+try {
+    $stmt_fahrer_absences = $pdo->prepare(
+        "SELECT CONCAT(f.Vorname, ' ', f.Nachname) AS name, a.abwesenheitsart, DATE_FORMAT(a.startdatum, '%d.%m.%Y') AS startdatum, DATE_FORMAT(a.enddatum, '%d.%m.%Y') AS enddatum
+         FROM FahrerAbwesenheiten a
+         JOIN Fahrer f ON a.FahrerID = f.FahrerID
+         WHERE CURDATE() BETWEEN a.startdatum AND a.enddatum"
+    );
+    $stmt_fahrer_absences->execute();
+    $fahrerAbsences = $stmt_fahrer_absences->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $fahrerAbsencesError = $e->getMessage();
+}
+
+$zentraleAbsences      = [];
+$zentraleAbsencesError = null;
+try {
+    $stmt_zentrale_absences = $pdo->prepare(
+        "SELECT CONCAT(mz.Vorname, ' ', mz.Nachname) AS name, az.typ, DATE_FORMAT(az.startdatum, '%d.%m.%Y') AS startdatum, DATE_FORMAT(az.enddatum, '%d.%m.%Y') AS enddatum
+         FROM abwesenheiten_zentrale az
+         JOIN mitarbeiter_zentrale mz ON az.mitarbeiter_id = mz.mitarbeiter_id
+         WHERE CURDATE() BETWEEN az.startdatum AND az.enddatum
+           AND mz.status = 'Aktiv'"
+    );
+    $stmt_zentrale_absences->execute();
+    $zentraleAbsences = $stmt_zentrale_absences->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $zentraleAbsencesError = $e->getMessage();
+}
+
+$totalAbsences = count($fahrerAbsences) + count($zentraleAbsences);
+
+// Heutige Schicht in der Zentrale
+$heutige_schicht     = [];
+$heutigeSchichtError = null;
+try {
+    $stmt_today = $pdo->prepare(
+        "SELECT CONCAT(mz.vorname, ' ', mz.nachname) AS name, s.name AS schicht
+         FROM dienstplan d
+         JOIN mitarbeiter_zentrale mz ON d.mitarbeiter_id = mz.mitarbeiter_id
+         JOIN schichten s ON d.schicht_id = s.schicht_id
+         WHERE DATE(d.datum) = CURDATE()
+           AND mz.status = 'Aktiv'"
+    );
+    $stmt_today->execute();
+    $heutige_schicht = $stmt_today->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $heutigeSchichtError = $e->getMessage();
+}
+
 $title = 'Dashboard';
 include '../includes/layout.php';
 ?>
-    <div class="container">
-        <header>
-			<h1 id="greeting"></h1>
-			<p id="subtitle"><?php echo $subtitle_message; ?></p>
-		</header>
+    <div class="container py-4 dashboard-container">
+        <header class="dashboard-hero card shadow-sm">
+            <div class="card-body">
+                <div class="hero-content">
+                    <p class="hero-eyebrow">Zentrale Übersicht</p>
+                    <h1 id="greeting" class="hero-title"></h1>
+                    <p class="hero-subtitle" id="subtitle"><?php echo $subtitle_message; ?></p>
+                </div>
+                <div class="hero-meta">
+                    <span class="hero-date"><i class="bi bi-calendar-event"></i> <?php echo htmlspecialchars($todayLabel); ?></span>
+                    <span class="hero-meta-badge"><i class="bi bi-building"></i> <?php echo htmlspecialchars(count($mitarbeiter)); ?> Teammitglieder</span>
+                </div>
+            </div>
+        </header>
 
+        <section class="dashboard-quickstats">
+            <article class="stat-card">
+                <div class="stat-icon bg-primary-subtle text-primary"><i class="bi bi-people-fill"></i></div>
+                <div class="stat-content">
+                    <span class="stat-label">Aktive Fahrer</span>
+                    <span class="stat-value"><?php echo htmlspecialchars($totalActiveDrivers); ?></span>
+                </div>
+            </article>
+            <article class="stat-card">
+                <div class="stat-icon bg-success-subtle text-success"><i class="bi bi-cake2-fill"></i></div>
+                <div class="stat-content">
+                    <span class="stat-label">Geburtstage heute</span>
+                    <span class="stat-value"><?php echo htmlspecialchars($birthdaysCount); ?></span>
+                </div>
+            </article>
+            <article class="stat-card">
+                <div class="stat-icon bg-warning-subtle text-warning"><i class="bi bi-emoji-frown-fill"></i></div>
+                <div class="stat-content">
+                    <span class="stat-label">Abwesenheiten</span>
+                    <span class="stat-value"><?php echo htmlspecialchars($totalAbsences); ?></span>
+                </div>
+            </article>
+            <article class="stat-card">
+                <div class="stat-icon bg-info-subtle text-info"><i class="bi bi-tools"></i></div>
+                <div class="stat-content">
+                    <span class="stat-label">Wartungen heute</span>
+                    <span class="stat-value"><?php echo htmlspecialchars($maintenancesDueTodayCount); ?></span>
+                </div>
+            </article>
+        </section>
 
-        <main>
-		
-			<?php
-				try {
-					$stmt = $pdo->prepare("
-						SELECT 
-							sfa.unternehmer AS firmenname,
-							COALESCE(f.Vorname, 'Unbekannt') AS fahrer_vorname,
-							COALESCE(f.Nachname, '') AS fahrer_nachname,
-							COALESCE(v.Kennzeichen, 'Ersatzfahrzeug') AS kennzeichen,
-							sfa.anmeldung,
-							sfa.fahrzeugflotte
-						FROM sync_fahreranmeldung sfa
-						LEFT JOIN Fahrer f 
-							ON sfa.fahrer = f.fms_alias OR sfa.fahrer = f.Fahrernummer
-						LEFT JOIN Fahrzeuge v 
-							ON sfa.kennung = v.Konzessionsnummer OR sfa.kennung = v.fms_alias
-						WHERE sfa.abmeldung IS NULL
-						ORDER BY firmenname, sfa.anmeldung DESC
-					");
-					$stmt->execute();
-					$aktive = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-					$firmenGruppiert = [];
-
-					foreach ($aktive as $eintrag) {
-						switch ($eintrag['firmenname']) {
-							case '720':
-								$anzeigeName = '4884 – Ihr Funktaxi';
-								break;
-							case '5810':
-								$anzeigeName = '4884 Service GbR';
-								break;
-							case '292':
-								$anzeigeName = 'Cityline GbR';
-								break;
-							default:
-								$anzeigeName = 'Unbekannter Unternehmer (' . $eintrag['firmenname'] . ')';
-						}
-						$firmenGruppiert[$anzeigeName][] = $eintrag;
-					}
-
-                                        if (!empty($firmenGruppiert)) {
-                                                foreach ($firmenGruppiert as $firma => $fahrerListe) {
-                                                        echo "<section class='widget card mb-3'><div class='card-body'>";
-                                                        echo "<h2>" . htmlspecialchars($firma) . "</h2>";
-                                                        echo "<ul>";
-                                                        foreach ($fahrerListe as $fahrer) {
-                                                                echo "<li><strong>" . htmlspecialchars($fahrer['fahrer_vorname']) . " " . htmlspecialchars($fahrer['fahrer_nachname']) . "</strong>";
-                                                                echo " – Kennzeichen: " . htmlspecialchars($fahrer['kennzeichen']);
-                                                                echo "</li>";
-                                                        }
-                                                        echo "</ul>";
-                                                        echo "</div></section>";
-                                                }
-                                        } else {
-                                                echo "<section class='widget card mb-3'><div class='card-body'><p>Aktuell sind keine Fahrer angemeldet.</p></div></section>";
-                                        }
-                                } catch (PDOException $e) {
-                                        echo "<section class='widget card mb-3'><div class='card-body'><p>Fehler bei der Fahrerabfrage: " . htmlspecialchars($e->getMessage()) . "</p></div></section>";
-                                }
-                                ?>
-
-            <section id="tageshighlights" class="widget card mb-3">
+        <main class="dashboard-main">
+            <section id="aktive-fahrer" class="widget card grid-span-2">
                 <div class="card-body">
-                <h2>Tageshighlights</h2>
-                <div id="birthdays">
-                    <h3>Geburtstage</h3>
-                    <ul>
-                        <?php
-                        try {
-                            // Fahrer-Geburtstage
-                            $stmt_fahrer = $pdo->prepare("SELECT CONCAT(Vorname, ' ', Nachname) AS name FROM Fahrer WHERE DATE_FORMAT(geburtsdatum, '%m-%d') = DATE_FORMAT(NOW(), '%m-%d')");
-                            $stmt_fahrer->execute();
-                            $fahrer_birthdays = $stmt_fahrer->fetchAll(PDO::FETCH_ASSOC);
-                        } catch (PDOException $e) {
-                            $fahrer_birthdays = [];
-                        }
-
-                        try {
-                            // Mitarbeiter-Zentrale-Geburtstage
-                            $stmt_zentrale = $pdo->prepare("SELECT CONCAT(Vorname, ' ', Nachname) AS name FROM mitarbeiter_zentrale WHERE DATE_FORMAT(geburtsdatum, '%m-%d') = DATE_FORMAT(NOW(), '%m-%d') AND status = 'Aktiv'");
-                            $stmt_zentrale->execute();
-                            $zentrale_birthdays = $stmt_zentrale->fetchAll(PDO::FETCH_ASSOC);
-                        } catch (PDOException $e) {
-                            $zentrale_birthdays = [];
-                        }
-
-                        // Zusammenführen der Ergebnisse
-                        $birthdays = array_merge($fahrer_birthdays, $zentrale_birthdays);
-
-                        if ($birthdays) {
-                            foreach ($birthdays as $person) {
-                                echo "<li>" . htmlspecialchars($person['name']) . "</li>";
-                            }
-                        } else {
-                            echo "<li>Keine Geburtstage heute.</li>";
-                        }
-                        ?>
-                    </ul>
-                </div>
-                <div id="fällige-termine">
-                    <h3>Fällige Wartungen</h3>
-                    <ul>
-                        <?php
-                        try {
-                            $stmt = $pdo->prepare(
-                                "SELECT DATE_FORMAT(w.Wartungsdatum, '%d.%m.%Y') AS Wartungsdatum, f.Konzessionsnummer, f.Kennzeichen, f.Marke, f.Modell 
-                                 FROM Wartung w 
-                                 JOIN Fahrzeuge f ON w.FahrzeugID = f.FahrzeugID 
-                                 WHERE DATE(w.Wartungsdatum) = CURDATE()"
-                            );
-                            $stmt->execute();
-                            $wartungen = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-                            if ($wartungen) {
-                                foreach ($wartungen as $wartung) {
-                                    echo "<li>" . htmlspecialchars($wartung['Wartungsdatum']) . ": " . htmlspecialchars($wartung['Marke']) . " " . htmlspecialchars($wartung['Modell']) . " (" . htmlspecialchars($wartung['Kennzeichen']) . ")</li>";
-                                }
-                            } else {
-                                echo "<li>Keine fälligen Wartungen heute.</li>";
-                            }
-                        } catch (PDOException $e) {
-                            echo "<li>Fehler bei der Abfrage: " . htmlspecialchars($e->getMessage()) . "</li>";
-                        }
-                        ?>
-                    </ul>
-                </div>
-                </div>
-            </section>
-
-            <section id="krank-urlaub" class="widget card mb-3">
-                <div class="card-body">
-                <h2>Krank/Urlaub</h2>
-                <div id="abteilungen">
-                    <div class='department'>
-                        <h3>Fahrer</h3>
-                        <ul>
-                            <?php
-                            try {
-                                $stmt_fahrer_absences = $pdo->prepare(
-                                    "SELECT CONCAT(f.Vorname, ' ', f.Nachname) AS name, a.abwesenheitsart, DATE_FORMAT(a.startdatum, '%d.%m.%Y') AS startdatum, DATE_FORMAT(a.enddatum, '%d.%m.%Y') AS enddatum 
-                                     FROM FahrerAbwesenheiten a 
-                                     JOIN Fahrer f ON a.FahrerID = f.FahrerID 
-                                     WHERE CURDATE() BETWEEN a.startdatum AND a.enddatum"
-                                );
-                                $stmt_fahrer_absences->execute();
-                                $fahrer_absences = $stmt_fahrer_absences->fetchAll(PDO::FETCH_ASSOC);
-
-                                if ($fahrer_absences) {
-                                    foreach ($fahrer_absences as $absence) {
-                                        echo "<li>" . htmlspecialchars($absence['name']) . " (" . htmlspecialchars($absence['abwesenheitsart']) . ", " . htmlspecialchars($absence['startdatum']) . " bis " . htmlspecialchars($absence['enddatum']) . ")</li>";
-                                    }
-                                } else {
-                                    echo "<li>Keine Abwesenheiten</li>";
-                                }
-                            } catch (PDOException $e) {
-                                echo "<li>Fehler bei der Abfrage: " . htmlspecialchars($e->getMessage()) . "</li>";
-                            }
-                            ?>
-                        </ul>
+                    <div class="section-header">
+                        <h2 class="section-title"><i class="bi bi-speedometer2"></i> Aktive Fahrer</h2>
+                        <p class="section-subtitle">Live-Übersicht der aktuell angemeldeten Fahrer</p>
                     </div>
-
-                    <div class='department'>
-                        <h3>Zentrale</h3>
-                        <ul>
-                            <?php
-                            try {
-                                $stmt_zentrale_absences = $pdo->prepare(
-                                    "SELECT CONCAT(mz.Vorname, ' ', mz.Nachname) AS name, az.typ, DATE_FORMAT(az.startdatum, '%d.%m.%Y') AS startdatum, DATE_FORMAT(az.enddatum, '%d.%m.%Y') AS enddatum
-                                     FROM abwesenheiten_zentrale az
-                                     JOIN mitarbeiter_zentrale mz ON az.mitarbeiter_id = mz.mitarbeiter_id
-                                     WHERE CURDATE() BETWEEN az.startdatum AND az.enddatum
-                                       AND mz.status = 'Aktiv'"
-                                );
-                                $stmt_zentrale_absences->execute();
-                                $zentrale_absences = $stmt_zentrale_absences->fetchAll(PDO::FETCH_ASSOC);
-
-                                if ($zentrale_absences) {
-                                    foreach ($zentrale_absences as $absence) {
-                                        echo "<li>" . htmlspecialchars($absence['name']) . " (" . htmlspecialchars($absence['typ']) . ", " . htmlspecialchars($absence['startdatum']) . " bis " . htmlspecialchars($absence['enddatum']) . ")</li>";
-                                    }
-                                } else {
-                                    echo "<li>Keine Abwesenheiten</li>";
-                                }
-                            } catch (PDOException $e) {
-                                echo "<li>Fehler bei der Abfrage: " . htmlspecialchars($e->getMessage()) . "</li>";
-                            }
-                            ?>
-                        </ul>
-                    </div>
-                </div>
-                </div>
-            </section>
-
-            <section id="tuev" class="widget card mb-3">
-                <div class="card-body">
-                <h2>Fällige TÜV</h2>
-                <ul>
-                    <?php
-                    try {
-                        $stmt = $pdo->prepare("SELECT Konzessionsnummer, Marke, Modell, DATE_FORMAT(HU, '%d.%m.%Y') AS HU FROM Fahrzeuge WHERE HU BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 3 MONTH) ORDER BY HU ASC");
-                        $stmt->execute();
-                        $fahrzeuge_hu = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-                        if ($fahrzeuge_hu) {
-                            foreach ($fahrzeuge_hu as $fahrzeug) {
-                                echo "<li>" . htmlspecialchars($fahrzeug['Konzessionsnummer']) . " - " . htmlspecialchars($fahrzeug['Marke']) . " " . htmlspecialchars($fahrzeug['Modell']) . ": " . htmlspecialchars($fahrzeug['HU']) . "</li>";
-                            }
-                        } else {
-                            echo "<li>Keine fälligen TÜV.</li>";
-                        }
-                    } catch (PDOException $e) {
-                        echo "<li>Fehler bei der Abfrage: " . htmlspecialchars($e->getMessage()) . "</li>";
-                    }
-                    ?>
-                </ul>
-                </div>
-            </section>
-
-            <section id="eichung" class="widget card mb-3">
-                <div class="card-body">
-                <h2>Wartungstermine</h2>
-                <ul>
-                    <?php
-                    try {
-                        $stmt = $pdo->prepare("
-						    SELECT DATE_FORMAT(w.Wartungsdatum, '%d.%m.%Y') AS FormattedDate, w.Werkstatt, f.Konzessionsnummer, f.Marke, f.Modell FROM Wartung w JOIN Fahrzeuge f ON w.FahrzeugID = f.FahrzeugID WHERE w.Wartungsdatum BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 3 MONTH) ORDER BY w.Wartungsdatum ASC");
-                        $stmt->execute();
-                        $fahrzeuge_eichung = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-                        if ($fahrzeuge_eichung) {
-                            foreach ($fahrzeuge_eichung as $fahrzeug) {
-                                echo "<li>" . htmlspecialchars($fahrzeug['Konzessionsnummer']) . " - " . htmlspecialchars($fahrzeug['Marke']) . ": " . htmlspecialchars($fahrzeug['FormattedDate']) . "</li>";
-                            }
-                        } else {
-                            echo "<li>Keine fälligen Eichungen.</li>";
-                        }
-                    } catch (PDOException $e) {
-                        echo "<li>Fehler bei der Abfrage: " . htmlspecialchars($e->getMessage()) . "</li>";
-                    }
-                    ?>
-                </ul>
-                </div>
-            </section>
-
-            <section id="pschein" class="widget card mb-3">
-                                <div class="card-body">
-                                <h2>Bald ablaufende P-Scheine</h2>
-                                <ul>
-					<?php
-					try {
-						$stmt = $pdo->prepare("SELECT CONCAT(Vorname, ' ', Nachname) AS Name, DATE_FORMAT(PScheinGueltigkeit, '%d.%m.%Y') AS PScheinGueltigkeit FROM Fahrer WHERE PScheinGueltigkeit BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 3 MONTH) ORDER BY PScheinGueltigkeit ASC");
-						$stmt->execute();
-						$fahrer_pschein = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-						if ($fahrer_pschein) {
-							foreach ($fahrer_pschein as $fahrer) {
-								echo "<li>" . htmlspecialchars($fahrer['Name']) . " - Gültig bis: " . htmlspecialchars($fahrer['PScheinGueltigkeit']) . "</li>";
-							}
-						} else {
-							echo "<li>Alle P-Scheine aktuell.</li>";
-						}
-					} catch (PDOException $e) {
-						echo "<li>Fehler bei der Abfrage: " . htmlspecialchars($e->getMessage()) . "</li>";
-					}
-					?>
+                    <?php if ($activeDriversError): ?>
+                        <p class="text-danger mb-0">Fehler bei der Fahrerabfrage: <?php echo htmlspecialchars($activeDriversError); ?></p>
+                    <?php elseif (!empty($activeDriversByCompany)): ?>
+                        <?php foreach ($activeDriversByCompany as $firma => $fahrerListe): ?>
+                            <div class="company-card">
+                                <div class="company-card-header">
+                                    <h3 class="company-title"><?php echo htmlspecialchars($firma); ?></h3>
+                                    <span class="badge text-bg-primary"><?php echo count($fahrerListe); ?> Fahrer</span>
+                                </div>
+                                <ul class="stacked-list">
+                                    <?php foreach ($fahrerListe as $fahrer): ?>
+                                        <li class="stacked-list-item">
+                                            <div class="list-primary"><?php echo htmlspecialchars(trim($fahrer['fahrer_vorname'] . ' ' . $fahrer['fahrer_nachname'])); ?></div>
+                                            <div class="list-secondary">
+                                                <span><i class="bi bi-car-front"></i> <?php echo htmlspecialchars($fahrer['kennzeichen']); ?></span>
+                                                <?php if (!empty($fahrer['fahrzeugflotte'])): ?>
+                                                    <span><i class="bi bi-diagram-3"></i> <?php echo htmlspecialchars($fahrer['fahrzeugflotte']); ?></span>
+                                                <?php endif; ?>
+                                            </div>
+                                            <?php if (!empty($fahrer['anmeldung'])): ?>
+                                                <div class="list-meta"><i class="bi bi-clock-history"></i> seit <?php echo htmlspecialchars(date('d.m.Y H:i', strtotime($fahrer['anmeldung']))); ?></div>
+                                            <?php endif; ?>
+                                        </li>
+                                    <?php endforeach; ?>
                                 </ul>
-                                </div>
-                        </section>
-			
-                        <section id="zentraler-dienstplan" class="widget card mb-3">
-                                <div class="card-body">
-                                <h2>Zentraler Dienstplan</h2>
-                                <div id="heutige-schicht">
-					<h3>Heutige Schicht</h3>
-					<ul>
-						<?php
-						try {
-                                                        $stmt_today = $pdo->prepare("
-                                                                SELECT CONCAT(mz.vorname, ' ', mz.nachname) AS name, s.name AS schicht
-                                                                FROM dienstplan d
-                                                                JOIN mitarbeiter_zentrale mz ON d.mitarbeiter_id = mz.mitarbeiter_id
-                                                                JOIN schichten s ON d.schicht_id = s.schicht_id
-                                                                WHERE DATE(d.datum) = CURDATE()
-                                                                  AND mz.status = 'Aktiv'
-                                                        ");
-							$stmt_today->execute();
-							$heutige_schicht = $stmt_today->fetchAll(PDO::FETCH_ASSOC);
+                            </div>
+                        <?php endforeach; ?>
+                    <?php else: ?>
+                        <p class="text-muted mb-0">Aktuell sind keine Fahrer angemeldet.</p>
+                    <?php endif; ?>
+                </div>
+            </section>
 
-							if ($heutige_schicht) {
-								foreach ($heutige_schicht as $schicht) {
-									echo "<li>" . htmlspecialchars($schicht['name']) . ": " . htmlspecialchars($schicht['schicht']) . "</li>";
-								}
-							} else {
-								echo "<li>Keine Schichtdaten für heute verfügbar.</li>";
-							}
-						} catch (PDOException $e) {
-							echo "<li>Fehler bei der Abfrage: " . htmlspecialchars($e->getMessage()) . "</li>";
-						}
-						?>
-					</ul>
-                                </div>
-                                </div>
-                        </section>
-
-            <section id="dienstplan-zentrale" class="widget card mb-3">
+            <section id="tageshighlights" class="widget card">
                 <div class="card-body">
-                <h2>Schichtplan Zentrale</h2>
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Mitarbeiter</th>
-                            <?php foreach ($dates as $date): ?>
-                                <th class="<?= $date['isWeekend'] ? 'weekend' : ''; ?>">
-                                    <?= htmlspecialchars($date['day']); ?>
-                                </th>
-                            <?php endforeach; ?>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if (!empty($mitarbeiter)): ?>
-                            <?php foreach ($mitarbeiter as $person): ?>
-                                <tr>
-                                    <td><?= htmlspecialchars($person['nachname'] . ', ' . $person['vorname']); ?></td>
-                                    <?php foreach ($dates as $date): ?>
-                                        <?php
-                                        $cellClass = '';
-                                        $cellText = '-';
+                    <div class="section-header">
+                        <h2 class="section-title"><i class="bi bi-stars"></i> Tageshighlights</h2>
+                        <p class="section-subtitle">Was heute wichtig ist</p>
+                    </div>
+                    <div class="two-column">
+                        <div class="info-block">
+                            <h3 class="info-title"><i class="bi bi-cake2"></i> Geburtstage</h3>
+                            <?php if ($birthdaysError): ?>
+                                <p class="text-danger mb-0">Fehler bei der Abfrage: <?php echo htmlspecialchars($birthdaysError); ?></p>
+                            <?php elseif (!empty($birthdays)): ?>
+                                <ul class="stacked-list">
+                                    <?php foreach ($birthdays as $person): ?>
+                                        <li class="stacked-list-item">
+                                            <div class="list-primary"><?php echo htmlspecialchars($person['name']); ?></div>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php else: ?>
+                                <p class="text-muted mb-0">Keine Geburtstage heute.</p>
+                            <?php endif; ?>
+                        </div>
+                        <div class="info-block">
+                            <h3 class="info-title"><i class="bi bi-tools"></i> Fällige Wartungen</h3>
+                            <?php if ($maintenancesDueTodayError): ?>
+                                <p class="text-danger mb-0">Fehler bei der Abfrage: <?php echo htmlspecialchars($maintenancesDueTodayError); ?></p>
+                            <?php elseif (!empty($maintenancesDueToday)): ?>
+                                <ul class="stacked-list">
+                                    <?php foreach ($maintenancesDueToday as $wartung): ?>
+                                        <li class="stacked-list-item">
+                                            <div class="list-primary"><?php echo htmlspecialchars($wartung['Marke'] . ' ' . $wartung['Modell']); ?></div>
+                                            <div class="list-secondary">
+                                                <span><i class="bi bi-calendar-date"></i> <?php echo htmlspecialchars($wartung['Wartungsdatum']); ?></span>
+                                                <span><i class="bi bi-123"></i> <?php echo htmlspecialchars($wartung['Kennzeichen']); ?></span>
+                                            </div>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php else: ?>
+                                <p class="text-muted mb-0">Keine fälligen Wartungen heute.</p>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            </section>
 
-                                        // Schicht aus Dienstplan abrufen
-                                        if (isset($dienstplanMap[$person['mitarbeiter_id']][$date['date']])) {
-                                            $schicht = $dienstplanMap[$person['mitarbeiter_id']][$date['date']];
-                                            $cellText = $schicht;
-                                            switch ($schicht) {
-                                                case 'F0': case 'F1': case 'F3':
-                                                    $cellClass = 'early-shift';
-                                                    break;
-                                                case 'F2':
-                                                    $cellClass = 'mid-shift';
-                                                    break;
-                                                case 'S0': case 'S1':
-                                                    $cellClass = 'late-shift';
-                                                    break;
-                                                case 'N':
-                                                    $cellClass = 'night-shift';
-                                                    break;
-                                            }
-                                        }
-                                        ?>
-                                        <td class="<?= $cellClass; ?>">
-                                            <?= htmlspecialchars($cellText); ?>
-                                        </td>
+            <section id="krank-urlaub" class="widget card grid-span-2">
+                <div class="card-body">
+                    <div class="section-header">
+                        <h2 class="section-title"><i class="bi bi-heart-pulse"></i> Krank &amp; Urlaub</h2>
+                        <p class="section-subtitle">Aktuelle Abwesenheiten in Fahrerteam und Zentrale</p>
+                    </div>
+                    <div class="two-column">
+                        <div class="info-block">
+                            <h3 class="info-title"><i class="bi bi-steering-wheel"></i> Fahrer</h3>
+                            <?php if ($fahrerAbsencesError): ?>
+                                <p class="text-danger mb-0">Fehler bei der Abfrage: <?php echo htmlspecialchars($fahrerAbsencesError); ?></p>
+                            <?php elseif (!empty($fahrerAbsences)): ?>
+                                <ul class="stacked-list">
+                                    <?php foreach ($fahrerAbsences as $absence): ?>
+                                        <li class="stacked-list-item">
+                                            <div class="list-primary"><?php echo htmlspecialchars($absence['name']); ?></div>
+                                            <div class="list-secondary">
+                                                <span class="badge text-bg-warning"><?php echo htmlspecialchars($absence['abwesenheitsart']); ?></span>
+                                                <span><i class="bi bi-calendar-date"></i> <?php echo htmlspecialchars($absence['startdatum']); ?> – <?php echo htmlspecialchars($absence['enddatum']); ?></span>
+                                            </div>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php else: ?>
+                                <p class="text-muted mb-0">Keine Abwesenheiten</p>
+                            <?php endif; ?>
+                        </div>
+                        <div class="info-block">
+                            <h3 class="info-title"><i class="bi bi-briefcase"></i> Zentrale</h3>
+                            <?php if ($zentraleAbsencesError): ?>
+                                <p class="text-danger mb-0">Fehler bei der Abfrage: <?php echo htmlspecialchars($zentraleAbsencesError); ?></p>
+                            <?php elseif (!empty($zentraleAbsences)): ?>
+                                <ul class="stacked-list">
+                                    <?php foreach ($zentraleAbsences as $absence): ?>
+                                        <li class="stacked-list-item">
+                                            <div class="list-primary"><?php echo htmlspecialchars($absence['name']); ?></div>
+                                            <div class="list-secondary">
+                                                <span class="badge text-bg-warning"><?php echo htmlspecialchars($absence['typ']); ?></span>
+                                                <span><i class="bi bi-calendar-date"></i> <?php echo htmlspecialchars($absence['startdatum']); ?> – <?php echo htmlspecialchars($absence['enddatum']); ?></span>
+                                            </div>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php else: ?>
+                                <p class="text-muted mb-0">Keine Abwesenheiten</p>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section id="tuev" class="widget card">
+                <div class="card-body">
+                    <div class="section-header">
+                        <h2 class="section-title"><i class="bi bi-shield-check"></i> Fällige TÜV</h2>
+                    </div>
+                    <?php if ($huDueError): ?>
+                        <p class="text-danger mb-0">Fehler bei der Abfrage: <?php echo htmlspecialchars($huDueError); ?></p>
+                    <?php elseif (!empty($huDue)): ?>
+                        <ul class="stacked-list">
+                            <?php foreach ($huDue as $fahrzeug): ?>
+                                <li class="stacked-list-item">
+                                    <div class="list-primary"><?php echo htmlspecialchars($fahrzeug['Marke'] . ' ' . $fahrzeug['Modell']); ?></div>
+                                    <div class="list-secondary">
+                                        <span><i class="bi bi-hash"></i> <?php echo htmlspecialchars($fahrzeug['Konzessionsnummer']); ?></span>
+                                        <span><i class="bi bi-calendar-date"></i> <?php echo htmlspecialchars($fahrzeug['HU']); ?></span>
+                                    </div>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php else: ?>
+                        <p class="text-muted mb-0">Keine TÜV-Termine in den nächsten drei Monaten.</p>
+                    <?php endif; ?>
+                </div>
+            </section>
+
+            <section id="eichung" class="widget card">
+                <div class="card-body">
+                    <div class="section-header">
+                        <h2 class="section-title"><i class="bi bi-wrench-adjustable"></i> Wartungstermine</h2>
+                    </div>
+                    <?php if ($upcomingMaintenancesError): ?>
+                        <p class="text-danger mb-0">Fehler bei der Abfrage: <?php echo htmlspecialchars($upcomingMaintenancesError); ?></p>
+                    <?php elseif (!empty($upcomingMaintenances)): ?>
+                        <ul class="stacked-list">
+                            <?php foreach ($upcomingMaintenances as $fahrzeug): ?>
+                                <li class="stacked-list-item">
+                                    <div class="list-primary"><?php echo htmlspecialchars($fahrzeug['Marke'] . ' ' . $fahrzeug['Modell']); ?></div>
+                                    <div class="list-secondary">
+                                        <span><i class="bi bi-hash"></i> <?php echo htmlspecialchars($fahrzeug['Konzessionsnummer']); ?></span>
+                                        <span><i class="bi bi-calendar-date"></i> <?php echo htmlspecialchars($fahrzeug['FormattedDate']); ?></span>
+                                    </div>
+                                    <?php if (!empty($fahrzeug['Werkstatt'])): ?>
+                                        <div class="list-meta"><i class="bi bi-geo-alt"></i> <?php echo htmlspecialchars($fahrzeug['Werkstatt']); ?></div>
+                                    <?php endif; ?>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php else: ?>
+                        <p class="text-muted mb-0">Keine geplanten Wartungen in den nächsten drei Monaten.</p>
+                    <?php endif; ?>
+                </div>
+            </section>
+
+            <section id="pschein" class="widget card">
+                <div class="card-body">
+                    <div class="section-header">
+                        <h2 class="section-title"><i class="bi bi-person-badge"></i> Bald ablaufende P-Scheine</h2>
+                    </div>
+                    <?php if ($pscheinError): ?>
+                        <p class="text-danger mb-0">Fehler bei der Abfrage: <?php echo htmlspecialchars($pscheinError); ?></p>
+                    <?php elseif (!empty($pscheinDue)): ?>
+                        <ul class="stacked-list">
+                            <?php foreach ($pscheinDue as $fahrer): ?>
+                                <li class="stacked-list-item">
+                                    <div class="list-primary"><?php echo htmlspecialchars($fahrer['Name']); ?></div>
+                                    <div class="list-secondary">
+                                        <span><i class="bi bi-calendar-date"></i> gültig bis <?php echo htmlspecialchars($fahrer['PScheinGueltigkeit']); ?></span>
+                                    </div>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php else: ?>
+                        <p class="text-muted mb-0">Alle P-Scheine sind aktuell.</p>
+                    <?php endif; ?>
+                </div>
+            </section>
+
+            <section id="zentraler-dienstplan" class="widget card grid-span-2">
+                <div class="card-body">
+                    <div class="section-header">
+                        <h2 class="section-title"><i class="bi bi-clock"></i> Zentraler Dienstplan</h2>
+                        <p class="section-subtitle">Wer ist heute in welcher Schicht eingeteilt?</p>
+                    </div>
+                    <div id="heutige-schicht" class="mb-4">
+                        <h3 class="info-title"><i class="bi bi-sunrise"></i> Heutige Schicht</h3>
+                        <?php if ($heutigeSchichtError): ?>
+                            <p class="text-danger mb-0">Fehler bei der Abfrage: <?php echo htmlspecialchars($heutigeSchichtError); ?></p>
+                        <?php elseif (!empty($heutige_schicht)): ?>
+                            <ul class="stacked-list">
+                                <?php foreach ($heutige_schicht as $schicht): ?>
+                                    <li class="stacked-list-item">
+                                        <div class="list-primary"><?php echo htmlspecialchars($schicht['name']); ?></div>
+                                        <div class="list-secondary"><span class="badge text-bg-secondary"><?php echo htmlspecialchars($schicht['schicht']); ?></span></div>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php else: ?>
+                            <p class="text-muted mb-0">Keine Schichtdaten für heute verfügbar.</p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </section>
+
+            <section id="dienstplan-zentrale" class="widget card grid-span-full">
+                <div class="card-body">
+                    <div class="section-header">
+                        <h2 class="section-title"><i class="bi bi-calendar3"></i> Schichtplan Zentrale (nächste Tage)</h2>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle dashboard-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Mitarbeiter</th>
+                                    <?php foreach ($dates as $date): ?>
+                                        <th scope="col" class="<?php echo $date['isWeekend'] ? 'weekend' : ''; ?>"><?php echo htmlspecialchars($date['day']); ?></th>
                                     <?php endforeach; ?>
                                 </tr>
-                            <?php endforeach; ?>
-                        <?php else: ?>
-                            <tr>
-                                <td colspan="<?= count($dates) + 1; ?>">Keine Mitarbeiter gefunden.</td>
-                            </tr>
-                        <?php endif; ?>
-                    </tbody>
-                </table>
+                            </thead>
+                            <tbody>
+                                <?php if (!empty($mitarbeiter)): ?>
+                                    <?php foreach ($mitarbeiter as $person): ?>
+                                        <tr>
+                                            <th scope="row"><?php echo htmlspecialchars($person['nachname'] . ', ' . $person['vorname']); ?></th>
+                                            <?php foreach ($dates as $date): ?>
+                                                <?php
+                                                $cellClass = '';
+                                                $cellText  = '-';
+
+                                                if (isset($dienstplanMap[$person['mitarbeiter_id']][$date['date']])) {
+                                                    $schicht  = $dienstplanMap[$person['mitarbeiter_id']][$date['date']];
+                                                    $cellText = $schicht;
+                                                    switch ($schicht) {
+                                                        case 'F0':
+                                                        case 'F1':
+                                                        case 'F3':
+                                                            $cellClass = 'early-shift';
+                                                            break;
+                                                        case 'F2':
+                                                            $cellClass = 'mid-shift';
+                                                            break;
+                                                        case 'S0':
+                                                        case 'S1':
+                                                            $cellClass = 'late-shift';
+                                                            break;
+                                                        case 'N':
+                                                            $cellClass = 'night-shift';
+                                                            break;
+                                                    }
+                                                }
+                                                ?>
+                                                <td class="<?php echo $cellClass; ?>"><?php echo htmlspecialchars($cellText); ?></td>
+                                            <?php endforeach; ?>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                <?php else: ?>
+                                    <tr>
+                                        <td colspan="<?php echo count($dates) + 1; ?>" class="text-center text-muted">Keine Mitarbeiter gefunden.</td>
+                                    </tr>
+                                <?php endif; ?>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </section>
-
         </main>
     </div>
-	<script>
-		document.addEventListener("DOMContentLoaded", () => {
-			const greetingMessage = "<?php echo $greeting_message; ?>";
-			const greetingElement = document.getElementById("greeting");
-			let i = 0;
+        <script>
+                document.addEventListener("DOMContentLoaded", () => {
+                        const greetingMessage = "<?php echo $greeting_message; ?>";
+                        const greetingElement = document.getElementById("greeting");
+                        let i = 0;
 
-			function typeGreeting() {
-				if (i < greetingMessage.length) {
-					greetingElement.textContent += greetingMessage.charAt(i);
-					i++;
-					setTimeout(typeGreeting, 100); // Geschwindigkeit des Tippens (100ms pro Buchstabe)
-				}
-			}
+                        function typeGreeting() {
+                                if (i < greetingMessage.length) {
+                                        greetingElement.textContent += greetingMessage.charAt(i);
+                                        i++;
+                                        setTimeout(typeGreeting, 100); // Geschwindigkeit des Tippens (100ms pro Buchstabe)
+                                }
+                        }
 
-			typeGreeting();
-		});
-	</script>
+                        typeGreeting();
+                });
+        </script>
 
     <script>
-        document.querySelector('.burger-menu').addEventListener('click', () => {
-            document.querySelector('.nav-links').classList.toggle('active');
-        });
+        const burger = document.querySelector('.burger-menu');
+        const navLinks = document.querySelector('.nav-links');
+        if (burger && navLinks) {
+            burger.addEventListener('click', () => {
+                navLinks.classList.toggle('active');
+            });
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restructure the dashboard PHP logic to pre-fetch data for quick statistics and richer sections
- redesign the dashboard markup with a hero header, statistic cards, and modernized content cards
- expand the dashboard stylesheet with new grid, card, and table styles to support the refreshed layout

## Testing
- php -l public/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68e3b1064638832b8fb02e51a534987f