### PR TITLE
Remove Schulung link from Admin menu

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -172,12 +172,6 @@ $menuEntries = [
                 'icon' => 'bi-people',
             ],
             [
-                'label' => 'Schulung',
-                'url' => 'schulungsverwaltung.php',
-                'roles' => ['Admin'],
-                'icon' => 'bi-journal-text',
-            ],
-            [
                 'label' => 'Nachrichtenrechte',
                 'url' => 'message_permissions.php',
                 'roles' => ['Admin'],


### PR DESCRIPTION
## Summary
- remove the Schulung navigation entry from the Admin menu so it no longer appears twice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b2482f88832bab664cb7f625c880