### PR TITLE
Fix inbox message sending via AJAX

### DIFF
--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -71,6 +71,25 @@ class Message
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public static function findWithSender(int $messageId): ?array
+    {
+        global $pdo;
+        $stmt = $pdo->prepare('
+            SELECT m.id, m.subject, m.body, m.created_at, m.read_at,
+                   m.sender_id, m.recipient_id,
+                   sender.Name AS sender_name,
+                   recipient.Name AS recipient_name
+            FROM messages m
+            JOIN Benutzer sender ON sender.BenutzerID = m.sender_id
+            JOIN Benutzer recipient ON recipient.BenutzerID = m.recipient_id
+            WHERE m.id = ?
+        ');
+        $stmt->execute([$messageId]);
+        $message = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $message !== false ? $message : null;
+    }
+
     public static function markConversationAsRead(int $userId, int $otherId): void
     {
         global $pdo;

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -138,10 +138,24 @@ document.addEventListener('DOMContentLoaded', function () {
       var formData = new FormData(chatForm);
       fetch(chatForm.action, {
         method: 'POST',
-        body: formData
+        body: formData,
+        headers: {
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest'
+        }
       })
-        .then(function (res) { return res.json(); })
+        .then(function (res) {
+          if (!res.ok) {
+            throw new Error('Fehler beim Senden der Nachricht (Status ' + res.status + ')');
+          }
+          return res.json();
+        })
         .then(function (msg) {
+          if (msg && msg.error) {
+            console.error(msg.error);
+            return;
+          }
+
           if (msg && msg.sender_name) {
             var newMessageHtml = '<div class="message sent">';
             newMessageHtml += '<p class="message-header"><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>';
@@ -157,7 +171,9 @@ document.addEventListener('DOMContentLoaded', function () {
           }
           bodyInput.value = '';
         })
-        .catch(function (err) { console.error(err); });
+        .catch(function (err) {
+          console.error(err);
+        });
     });
   }
 });


### PR DESCRIPTION
## Summary
- add a model helper to load a message with sender and recipient metadata
- return JSON responses from the Postfach store endpoint for AJAX requests and surface validation errors
- update the inbox JavaScript to request JSON, handle errors, and append the new message without reloading

## Testing
- php -l public/postfach.php
- php -l app/Models/Message.php

------
https://chatgpt.com/codex/tasks/task_e_68e3b26d5c44832bbe5803bfe817b46f