### PR TITLE
Format displayed dates with two-digit years

### DIFF
--- a/cron/send_daily_sales.php
+++ b/cron/send_daily_sales.php
@@ -134,7 +134,7 @@ try {
     $totalSales = array_sum(array_column($yesterdayData, 'total_sales'));
 
     $recipients = getEmailRecipients($pdo);
-    $dateLabel  = date('d.m.Y', strtotime('yesterday'));
+    $dateLabel  = date('d.m.y', strtotime('yesterday'));
 
     foreach ($recipients as $recipient) {
         // Kompakteres, zentriertes Layout mit reduzierter Schriftgröße und Padding

--- a/cron/send_weekly_sales.php
+++ b/cron/send_weekly_sales.php
@@ -57,7 +57,7 @@ function getLastWeekRange(): array {
 }
 
 function formatDE(DateTime $dt): string {
-    return $dt->format('d.m.Y');
+    return $dt->format('d.m.y');
 }
 
 function kwLabel(DateTime $anyDayOfWeek): string {

--- a/public/abwesenheit_fahrer.php
+++ b/public/abwesenheit_fahrer.php
@@ -173,8 +173,8 @@ include __DIR__ . '/../includes/layout.php';
           <?php foreach ($urlaubAntraege as $antrag): ?>
             <li>
               <?= htmlspecialchars($antrag['nachname'] . ', ' . $antrag['vorname']) ?>:
-              <?= date('d.m.Y', strtotime($antrag['startdatum'])) ?> bis 
-              <?= date('d.m.Y', strtotime($antrag['enddatum'])) ?>
+              <?= date('d.m.y', strtotime($antrag['startdatum'])) ?> bis 
+              <?= date('d.m.y', strtotime($antrag['enddatum'])) ?>
 			  <?= htmlspecialchars($antrag['kommentar']) ?>:
               <button onclick="window.location.href='approve_urlaub.php?id=<?= $antrag['abwesenheit_id'] ?>'">Genehmigen</button>
               <button onclick="window.location.href='reject_urlaub.php?id=<?= $antrag['abwesenheit_id'] ?>'">Ablehnen</button>

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -106,7 +106,7 @@ $daysOfWeek = [
     'Saturday'  => 'Samstag',
     'Sunday'    => 'Sonntag',
 ];
-$todayLabel = ($daysOfWeek[date('l')] ?? date('l')) . ', ' . date('d.m.Y');
+$todayLabel = ($daysOfWeek[date('l')] ?? date('l')) . ', ' . date('d.m.y');
 
 // Aktive Fahrer strukturieren
 $activeDriversByCompany = [];
@@ -372,7 +372,7 @@ include '../includes/layout.php';
                                                 <?php endif; ?>
                                             </div>
                                             <?php if (!empty($fahrer['anmeldung'])): ?>
-                                                <div class="list-meta"><i class="bi bi-clock-history"></i> seit <?php echo htmlspecialchars(date('d.m.Y H:i', strtotime($fahrer['anmeldung']))); ?></div>
+                                                <div class="list-meta"><i class="bi bi-clock-history"></i> seit <?php echo htmlspecialchars(date('d.m.y H:i', strtotime($fahrer['anmeldung']))); ?></div>
                                             <?php endif; ?>
                                         </li>
                                     <?php endforeach; ?>

--- a/public/driver/dashboard.php
+++ b/public/driver/dashboard.php
@@ -432,7 +432,7 @@ include __DIR__ . '/../../includes/layout.php';
 				</div>
 				<div class="hinweis-text">
 					<strong>Info:</strong><br>
-					Yannik plant am <strong><?= date('d.m.Y', strtotime($naechsteAbrechnung['Datum'])) ?></strong><br>
+					Yannik plant am <strong><?= date('d.m.y', strtotime($naechsteAbrechnung['Datum'])) ?></strong><br>
 					gegen <strong><?= htmlspecialchars($naechsteAbrechnung['Uhrzeit']) ?> Uhr</strong> zur Abrechnung zu kommen.
 				</div>
 			</div>
@@ -505,7 +505,7 @@ include __DIR__ . '/../../includes/layout.php';
                                 $bargeld = $umsatz - $ausgaben;
                             ?>
                             <tr>
-                                <td data-label="Datum"><?= htmlspecialchars(DateTime::createFromFormat('Y-m-d', $eintrag['Datum'])->format('d.m.Y')) ?></td>
+                                <td data-label="Datum"><?= htmlspecialchars(DateTime::createFromFormat('Y-m-d', $eintrag['Datum'])->format('d.m.y')) ?></td>
                                 <td data-label="Gesamtumsatz"><?= number_format($umsatz, 2, ',', '.') ?> €</td>
                                 <td data-label="Bargeld"><?= number_format($bargeld, 2, ',', '.') ?> €</td>
                                 <td class="actions">

--- a/public/driver/fahrzeug.php
+++ b/public/driver/fahrzeug.php
@@ -95,7 +95,7 @@ try {
 
 function formatDateTime($datetime) {
     $date = new DateTime($datetime);
-    return $date->format('d.m.Y');
+    return $date->format('d.m.y');
 }
 
 $title = 'Meine Fahrzeuge';

--- a/public/driver/personal.php
+++ b/public/driver/personal.php
@@ -285,11 +285,11 @@ include __DIR__ . '/../../includes/layout.php';
         </tr>
         <tr>
           <th>Führerschein gültig bis:</th>
-          <td><?= htmlspecialchars(date('d.m.Y', strtotime($fahrer['FuehrerscheinGueltigkeit']))) ?></td>
+          <td><?= htmlspecialchars(date('d.m.y', strtotime($fahrer['FuehrerscheinGueltigkeit']))) ?></td>
         </tr>
         <tr>
           <th>P-Schein gültig bis:</th>
-          <td><?= htmlspecialchars(date('d.m.Y', strtotime($fahrer['PScheinGueltigkeit']))) ?></td>
+          <td><?= htmlspecialchars(date('d.m.y', strtotime($fahrer['PScheinGueltigkeit']))) ?></td>
         </tr>
       </table>
     </div>
@@ -313,7 +313,7 @@ include __DIR__ . '/../../includes/layout.php';
 			  </span>
 			  <strong><?= htmlspecialchars($eintrag['abwesenheitsart']) ?></strong> – 
 			  <?= htmlspecialchars($eintrag['grund']) ?><br>
-			  <small>von <?= date('d.m.Y', strtotime($eintrag['startdatum'])) ?> bis <?= date('d.m.Y', strtotime($eintrag['enddatum'])) ?></small>
+			  <small>von <?= date('d.m.y', strtotime($eintrag['startdatum'])) ?> bis <?= date('d.m.y', strtotime($eintrag['enddatum'])) ?></small>
 			  <?php if($eintrag['abwesenheitsart'] === 'Urlaub'): ?>
 				<?php 
 				  $status = $eintrag['status'] ?? 'nicht gesetzt';

--- a/public/driver/statistics.php
+++ b/public/driver/statistics.php
@@ -26,19 +26,19 @@ switch ($zeitraum) {
     case 'tag':
         $start_date = date('Y-m-d', strtotime("$offset day"));
         $end_date = $start_date;
-        $anzeige_zeitraum = date("d.m.Y", strtotime($start_date));
+        $anzeige_zeitraum = date("d.m.y", strtotime($start_date));
         break;
 
     case 'woche':
         $start_date = date('Y-m-d', strtotime("monday this week +$offset week"));
         $end_date = date('Y-m-d', strtotime("sunday this week +$offset week"));
-        $anzeige_zeitraum = date("d.m.Y", strtotime($start_date)) . " - " . date("d.m.Y", strtotime($end_date));
+        $anzeige_zeitraum = date("d.m.y", strtotime($start_date)) . " - " . date("d.m.y", strtotime($end_date));
         break;
 
     case 'monat':
         $start_date = date('Y-m-01', strtotime("$offset month"));
         $end_date = date('Y-m-t', strtotime("$offset month"));
-        $anzeige_zeitraum = date("d.m.Y", strtotime($start_date)) . " - " . date("d.m.Y", strtotime($end_date));
+        $anzeige_zeitraum = date("d.m.y", strtotime($start_date)) . " - " . date("d.m.y", strtotime($end_date));
         break;
 
     case 'quartal':
@@ -47,7 +47,7 @@ switch ($zeitraum) {
         $start_month = (($aktuelles_quartal - 1) * 3) + 1;
         $start_date = date('Y-m-d', mktime(0, 0, 0, $start_month, 1, $jahr));
         $end_date = date('Y-m-t', mktime(0, 0, 0, $start_month + 2, 1, $jahr));
-        $anzeige_zeitraum = date("d.m.Y", strtotime($start_date)) . " - " . date("d.m.Y", strtotime($end_date));
+        $anzeige_zeitraum = date("d.m.y", strtotime($start_date)) . " - " . date("d.m.y", strtotime($end_date));
         break;
 
     case 'jahr':
@@ -61,7 +61,7 @@ switch ($zeitraum) {
         $zeitraum = 'woche';
         $start_date = date('Y-m-d', strtotime("monday this week +$offset week"));
         $end_date = date('Y-m-d', strtotime("sunday this week +$offset week"));
-        $anzeige_zeitraum = date("d.m.Y", strtotime($start_date)) . " - " . date("d.m.Y", strtotime($end_date));
+        $anzeige_zeitraum = date("d.m.y", strtotime($start_date)) . " - " . date("d.m.y", strtotime($end_date));
         break;
 }
 
@@ -158,7 +158,7 @@ include __DIR__ . '/../../includes/layout.php';
                     <?php foreach ($umsatz_pro_tag as $eintrag): ?>
                         <?php $umsatz = $eintrag['GesamtUmsatz'] ?? 0; ?>
                         <tr>
-                            <td><?= date("d.m.Y", strtotime($eintrag['Datum'])) ?></td>
+                            <td><?= date("d.m.y", strtotime($eintrag['Datum'])) ?></td>
                             <td><?= number_format($umsatz, 2, ',', '.') ?> €</td>
                         </tr>
                     <?php endforeach; ?>

--- a/public/export_fahrer_umsatz.php
+++ b/public/export_fahrer_umsatz.php
@@ -125,8 +125,8 @@ try {
 }
 
 $werktage = workdaysBetween($start_date, $end_date);
-$startDatumFormat = date('d.m.Y', strtotime($start_date));
-$endDatumFormat = date('d.m.Y', strtotime($end_date));
+$startDatumFormat = date('d.m.y', strtotime($start_date));
+$endDatumFormat = date('d.m.y', strtotime($end_date));
 
 // PDF erstellen
 $pdf = new FPDF();
@@ -156,8 +156,8 @@ for ($i = 0; $i < $maxRows; $i++) {
     // Krankheitsdaten
     if (isset($krankDetails[$i])) {
         $detail = $krankDetails[$i];
-        $krankStart = date('d.m.Y', strtotime($detail['start']));
-        $krankEnde = date('d.m.Y', strtotime($detail['ende']));
+        $krankStart = date('d.m.y', strtotime($detail['start']));
+        $krankEnde = date('d.m.y', strtotime($detail['ende']));
         $days = (strtotime($detail['ende']) - strtotime($detail['start'])) / (60 * 60 * 24) + 1;
         $krankText = "{$detail['grund']} ({$krankStart} - {$krankEnde}, {$days} Tage)";
     } else {
@@ -167,8 +167,8 @@ for ($i = 0; $i < $maxRows; $i++) {
     // Urlaubsdaten
     if (isset($urlaubDetails[$i])) {
         $detail = $urlaubDetails[$i];
-        $urlaubStart = date('d.m.Y', strtotime($detail['start']));
-        $urlaubEnde = date('d.m.Y', strtotime($detail['ende']));
+        $urlaubStart = date('d.m.y', strtotime($detail['start']));
+        $urlaubEnde = date('d.m.y', strtotime($detail['ende']));
         $days = (strtotime($detail['ende']) - strtotime($detail['start'])) / (60 * 60 * 24) + 1;
         $urlaubText = "{$detail['grund']} ({$urlaubStart} - {$urlaubEnde}, {$days} Tage)";
     } else {

--- a/public/fahrer.php
+++ b/public/fahrer.php
@@ -53,7 +53,7 @@ include __DIR__ . '/../includes/layout.php';
 			<div class="hinweis-box" style="background: <?= $mitteilung['wichtig'] ? '#ffe4e4' : '#fffae6' ?>; border: 1px solid <?= $mitteilung['wichtig'] ? '#cc0000' : '#e6c300' ?>; padding: 10px; margin-bottom: 20px;">
 				<strong>📢 Mitteilung an alle Fahrer:</strong><br>
 				<?= nl2br(htmlspecialchars($mitteilung['nachricht'])) ?><br><br>
-				<small>Gültig bis: <?= date('d.m.Y', strtotime($mitteilung['gueltig_bis'])) ?> | erstellt von <?= htmlspecialchars($mitteilung['erstellt_von']) ?></small>
+				<small>Gültig bis: <?= date('d.m.y', strtotime($mitteilung['gueltig_bis'])) ?> | erstellt von <?= htmlspecialchars($mitteilung['erstellt_von']) ?></small>
 
 				<div style="margin-top: 10px;">
 					<a class="btn-sm" href="?aktion=toggle_wichtig&id=<?= $mitteilung['id'] ?>">Wichtig <?= $mitteilung['wichtig'] ? '🔴' : '⚪' ?></a>
@@ -94,8 +94,8 @@ include __DIR__ . '/../includes/layout.php';
                             <td><?= htmlspecialchars($driver['Vorname']) ?></td>
                             <td><?= htmlspecialchars($driver['Nachname']) ?></td>
                             <td><?= htmlspecialchars($driver['Telefonnummer']) ?></td>
-                            <td><?= htmlspecialchars(date('d.m.Y', strtotime($driver['FuehrerscheinGueltigkeit']))) ?></td>
-                            <td><?= htmlspecialchars(date('d.m.Y', strtotime($driver['PScheinGueltigkeit']))) ?></td>
+                            <td><?= htmlspecialchars(date('d.m.y', strtotime($driver['FuehrerscheinGueltigkeit']))) ?></td>
+                            <td><?= htmlspecialchars(date('d.m.y', strtotime($driver['PScheinGueltigkeit']))) ?></td>
                             <td>
                                 <a href="fahrer_bearbeiten.php?id=<?= $driver['FahrerID'] ?>" class="btn-sm">Bearbeiten</a>
                             </td>

--- a/public/fahrer_umsatz.php
+++ b/public/fahrer_umsatz.php
@@ -353,7 +353,7 @@ include __DIR__ . '/../includes/layout.php';
                     <?php if (!empty($umsatzDaten)): ?>
                         <?php foreach ($umsatzDaten as $umsatz): ?>
                             <tr>
-                                <td><?= htmlspecialchars(date('d.m.Y', strtotime($umsatz['Datum']))) ?></td>
+                                <td><?= htmlspecialchars(date('d.m.y', strtotime($umsatz['Datum']))) ?></td>
                                 <td><?= number_format($umsatz['TaxameterUmsatz'], 2, ',', '.') ?></td>
                                 <td><?= number_format($umsatz['OhneTaxameter'], 2, ',', '.') ?></td>
                                 <td><?= number_format($umsatz['Kartenzahlung'], 2, ',', '.') ?></td>

--- a/public/fahrzeug_bearbeiten.php
+++ b/public/fahrzeug_bearbeiten.php
@@ -191,7 +191,7 @@ include __DIR__ . '/../includes/layout.php';
                             <td><?= htmlspecialchars($eintrag['Name'] ?? 'Unbekannter Fahrer') ?></td>
                             <td><?= htmlspecialchars($eintrag['Schicht'] ?? '-') ?></td>
                             <td><?= htmlspecialchars($eintrag['Aktion']) ?></td>
-                            <td><?= htmlspecialchars(date('d.m.Y H:i', strtotime($eintrag['Datum']))) ?></td>
+                            <td><?= htmlspecialchars(date('d.m.y H:i', strtotime($eintrag['Datum']))) ?></td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>

--- a/public/fahrzeug_overview.php
+++ b/public/fahrzeug_overview.php
@@ -37,8 +37,8 @@ include __DIR__ . '/../includes/layout.php';
                             <td><?= htmlspecialchars($fahrzeug['Modell']) ?></td>
                             <td><?= htmlspecialchars($fahrzeug['Konzessionsnummer']) ?></td>
                             <td><?= htmlspecialchars($fahrzeug['Typ']) ?></td>
-                            <td><?= htmlspecialchars(date('d.m.Y', strtotime($fahrzeug['HU']))) ?></td>
-                            <td><?= htmlspecialchars(date('d.m.Y', strtotime($fahrzeug['Eichung']))) ?></td>
+                            <td><?= htmlspecialchars(date('d.m.y', strtotime($fahrzeug['HU']))) ?></td>
+                            <td><?= htmlspecialchars(date('d.m.y', strtotime($fahrzeug['Eichung']))) ?></td>
                             <td>
                                 <a href="fahrzeug_bearbeiten.php?id=<?= htmlspecialchars($fahrzeug['FahrzeugID']) ?>" class="btn-sm">Bearbeiten</a>
                             </td>

--- a/public/fahrzeuge.php
+++ b/public/fahrzeuge.php
@@ -122,8 +122,8 @@ include __DIR__ . '/../includes/layout.php';
 			endif; ?>
 			<tr class="fahrzeug <?= strtolower($fahrzeug['Fahrzeugtyp']) ?>">
 				<td><?= htmlspecialchars($fahrzeug['Konzessionsnummer']) ?> <small><?= htmlspecialchars($fahrzeug['Kennzeichen']) ?></small></td>
-				<td><?= htmlspecialchars(date('d.m.Y', strtotime($fahrzeug['HU']))) ?></td>
-				<td><?= htmlspecialchars(date('d.m.Y', strtotime($fahrzeug['Eichung']))) ?></td>
+				<td><?= htmlspecialchars(date('d.m.y', strtotime($fahrzeug['HU']))) ?></td>
+				<td><?= htmlspecialchars(date('d.m.y', strtotime($fahrzeug['Eichung']))) ?></td>
 				<td><?= htmlspecialchars($fahrzeug['Tagfahrer'] ?? '-') ?></td>
 				<td><?= htmlspecialchars($fahrzeug['Nachtfahrer'] ?? '-') ?></td>
 			</tr>
@@ -142,7 +142,7 @@ include __DIR__ . '/../includes/layout.php';
 					<li>
 						<?= htmlspecialchars($fahrzeug['Konzessionsnummer']) ?> - 
 						<?= htmlspecialchars($fahrzeug['Marke']) ?> <?= htmlspecialchars($fahrzeug['Modell']) ?> 
-						(<?= htmlspecialchars(date('d.m.Y', strtotime($fahrzeug['HU']))) ?>)
+						(<?= htmlspecialchars(date('d.m.y', strtotime($fahrzeug['HU']))) ?>)
 					</li>
 				<?php endforeach; ?>
 			</ul>
@@ -154,7 +154,7 @@ include __DIR__ . '/../includes/layout.php';
 					<li>
 						<?= htmlspecialchars($fahrzeug['Konzessionsnummer']) ?> - 
 						<?= htmlspecialchars($fahrzeug['Marke']) ?> <?= htmlspecialchars($fahrzeug['Modell']) ?> 
-						(<?= htmlspecialchars(date('d.m.Y', strtotime($fahrzeug['Eichung']))) ?>)
+						(<?= htmlspecialchars(date('d.m.y', strtotime($fahrzeug['Eichung']))) ?>)
 					</li>
 				<?php endforeach; ?>
 			</ul>
@@ -165,7 +165,7 @@ include __DIR__ . '/../includes/layout.php';
 				<?php foreach ($fahrer_pschein as $fahrer): ?>
 					<li>
 						<?= htmlspecialchars($fahrer['Name']) ?> 
-						(<?= htmlspecialchars(date('d.m.Y', strtotime($fahrer['PScheinGueltigkeit']))) ?>)
+						(<?= htmlspecialchars(date('d.m.y', strtotime($fahrer['PScheinGueltigkeit']))) ?>)
 					</li>
 				<?php endforeach; ?>
 			</ul>
@@ -178,7 +178,7 @@ include __DIR__ . '/../includes/layout.php';
 						<?= htmlspecialchars($wartung['Konzessionsnummer']) ?> - 
 						<?= htmlspecialchars($wartung['Marke']) ?> <?= htmlspecialchars($wartung['Modell']) ?>: 
 						<?= htmlspecialchars($wartung['Werkstatt']) ?> 
-						(<?= htmlspecialchars(date('d.m.Y', strtotime($wartung['Wartungsdatum']))) ?>)
+						(<?= htmlspecialchars(date('d.m.y', strtotime($wartung['Wartungsdatum']))) ?>)
 					</li>
 				<?php endforeach; ?>
 			</ul>

--- a/public/pdf_alle_bestaetigt.php
+++ b/public/pdf_alle_bestaetigt.php
@@ -38,7 +38,7 @@ foreach ($teilnehmerListe as $teilnehmer) {
         'Nachname' => $teilnehmer['nachname'],
         'Straße' => $teilnehmer['strasse'] . ' ' . $teilnehmer['hausnummer'],
         'PLZ / Ort' => $teilnehmer['postleitzahl'] . ' ' . $teilnehmer['ort'],
-        'Geburtsdatum' => date('d.m.Y', strtotime($teilnehmer['geburtsdatum'])),
+        'Geburtsdatum' => date('d.m.y', strtotime($teilnehmer['geburtsdatum'])),
         'Handynummer' => $teilnehmer['handynummer'],
         'Email' => $teilnehmer['email'],
         'Unternehmer' => $teilnehmer['unternehmer']
@@ -54,6 +54,6 @@ foreach ($teilnehmerListe as $teilnehmer) {
 }
 
 // Dateiname z. B. mit Datum
-$filename = 'Schulung_Alle_Bestaetigten_' . date('d-m-Y') . '.pdf';
+$filename = 'Schulung_Alle_Bestaetigten_' . date('d-m-y') . '.pdf';
 $pdf->Output('D', $filename);
 exit();

--- a/public/pdf_generieren.php
+++ b/public/pdf_generieren.php
@@ -41,7 +41,7 @@ if (isset($_GET['id'])) {
         'Nachname' => $teilnehmer['nachname'],
         'Straße' => $teilnehmer['strasse'] . ' ' . $teilnehmer['hausnummer'],
         'PLZ / Ort' => $teilnehmer['postleitzahl'] . ' ' . $teilnehmer['ort'],
-        'Geburtsdatum' => date('d.m.Y', strtotime($teilnehmer['geburtsdatum'])),
+        'Geburtsdatum' => date('d.m.y', strtotime($teilnehmer['geburtsdatum'])),
         'Handynummer' => $teilnehmer['handynummer'],
         'Email' => $teilnehmer['email'],
         'Unternehmer' => $teilnehmer['unternehmer']

--- a/public/sauberkeit.php
+++ b/public/sauberkeit.php
@@ -150,7 +150,7 @@ include __DIR__ . '/../includes/layout.php';
                     <tr>
                         <td><?= htmlspecialchars($kontrolle['konzession']) ?></td>
                         <td><?= htmlspecialchars($kontrolle['vorname'] . ' ' . $kontrolle['nachname']) ?></td>
-                        <td><?= htmlspecialchars(date('d.m.Y', strtotime($kontrolle['datum']))) ?></td>
+                        <td><?= htmlspecialchars(date('d.m.y', strtotime($kontrolle['datum']))) ?></td>
                         <td><?= htmlspecialchars($kontrolle['sauberkeitaussen']) ?> <?= getBewertungIcon($kontrolle['sauberkeitaussen']) ?></td>
                         <td><?= htmlspecialchars($kontrolle['sauberkeitinnen']) ?> <?= getBewertungIcon($kontrolle['sauberkeitinnen']) ?></td>
                         <td><?= htmlspecialchars($kontrolle['reifendruck']) ?> bar</td>

--- a/public/schulungsverwaltung.php
+++ b/public/schulungsverwaltung.php
@@ -108,7 +108,7 @@ function versendeEinladung($id, $termin){
     $vorname         = $teilnehmer['vorname'];
     $email           = $teilnehmer['email'];
     $praxistagdatum  = DateTime::createFromFormat('Y-m-d', $termin)
-                        ->format('d.m.Y');
+                        ->format('d.m.y');
 
     /* E‑Mail verschicken (versand.php) */
     if (sendInvitation($id, $vorname, $email, $praxistagdatum)) {
@@ -354,7 +354,7 @@ include __DIR__ . '/../includes/layout.php';
 	</div>
 	<?php if ($nextTermin): ?>
 		<?php
-			$dateDe = (new DateTime($nextTermin))->format('d.m.Y');
+			$dateDe = (new DateTime($nextTermin))->format('d.m.y');
 		?>
 		<div class="alert alert-warning d-flex justify-content-center gap-4 align-items-center">
 			<strong>Nächster Praxistag: <?= $dateDe ?></strong>
@@ -444,7 +444,7 @@ include __DIR__ . '/../includes/layout.php';
                     <tr>
 						<td>
 							<?php if (!empty($row['gesperrt_bis']) && new DateTime($row['gesperrt_bis']) > new DateTime()): ?>
-								<i class="fas fa-ban text-danger" title="Gesperrt bis <?= date('d.m.Y', strtotime($row['gesperrt_bis'])) ?>"></i>
+								<i class="fas fa-ban text-danger" title="Gesperrt bis <?= date('d.m.y', strtotime($row['gesperrt_bis'])) ?>"></i>
 							<?php elseif ((int)$row['nicht_bestanden_count'] > 0): ?>
 								<i class="fas fa-rotate-left text-warning" title="Wiederholer (bereits durchgefallen)"></i>
 							<?php else: ?>
@@ -511,7 +511,7 @@ include __DIR__ . '/../includes/layout.php';
 							<td>
 								<?php if ($row['gesperrt_bis'] !== null && new DateTime($row['gesperrt_bis']) > new DateTime()): ?>
 									<div class="mb-1 text-danger">
-										<i class="fas fa-ban"></i> Gesperrt bis <?= date('d.m.Y', strtotime($row['gesperrt_bis'])) ?>
+										<i class="fas fa-ban"></i> Gesperrt bis <?= date('d.m.y', strtotime($row['gesperrt_bis'])) ?>
 									</div>
 									<form method="POST" class="d-inline">
 										<input type="hidden" name="id" value="<?php echo $row['id']; ?>">
@@ -526,7 +526,7 @@ include __DIR__ . '/../includes/layout.php';
 						<?php else: ?>
 							<td>
 								<?php if ($row['gesperrt_bis'] !== null && new DateTime($row['gesperrt_bis']) > new DateTime()): ?>
-									<span class="text-danger"><i class="fas fa-ban"></i> Gesperrt bis <?= date('d.m.Y', strtotime($row['gesperrt_bis'])) ?></span>
+									<span class="text-danger"><i class="fas fa-ban"></i> Gesperrt bis <?= date('d.m.y', strtotime($row['gesperrt_bis'])) ?></span>
 								<?php else: ?>
 									<span class="text-success"><i class="fas fa-check-circle"></i> Nicht gesperrt</span>
 								<?php endif; ?>

--- a/public/service.php
+++ b/public/service.php
@@ -62,7 +62,7 @@ include __DIR__ . '/../includes/layout.php';
 								<?= htmlspecialchars($wartung['Marke']) ?> 
 								<?= htmlspecialchars($wartung['Modell']) ?>
 							</td>
-							<td><?= htmlspecialchars(date('d.m.Y', strtotime($wartung['Wartungsdatum']))) ?></td>
+							<td><?= htmlspecialchars(date('d.m.y', strtotime($wartung['Wartungsdatum']))) ?></td>
 							<td><?= htmlspecialchars(number_format($wartung['Kilometerstand'], 0, ',', '.')) ?> km</td>
 							<td><?= htmlspecialchars($wartung['Beschreibung'] ?? 'Keine Beschreibung') ?></td>
 							<td><?= htmlspecialchars(number_format($wartung['Kosten'], 2, ',', '.')) ?> €</td>

--- a/public/umsatz_dashboard.php
+++ b/public/umsatz_dashboard.php
@@ -183,7 +183,7 @@ include __DIR__ . '/../includes/layout.php';
 							<?php if ($datum === '1970-01-01' || empty($fahrerDaten)) continue; // Zeile überspringen, wenn 01.01.1970 ?>
 							
 							<tr>
-								<td><?= date('d.m.Y', strtotime($datum)) ?></td>
+								<td><?= date('d.m.y', strtotime($datum)) ?></td>
 								<?php foreach ($fahrerDerFirma as $fahrer => $fahrerID): ?>
 									<td>
 										<?= number_format($fahrerDaten[$fahrer]['GesamtUmsatz'], 2, ',', '.') ?> €

--- a/public/umsatz_verlauf.php
+++ b/public/umsatz_verlauf.php
@@ -37,7 +37,7 @@ if (empty($aenderungen)) {
         <?php foreach ($aenderungen as $log): ?>
             <tr>
                 <td><?= htmlspecialchars($log['Benutzer']) ?></td>
-                <td><?= date('d.m.Y H:i', strtotime($log['Zeitpunkt'])) ?></td>
+                <td><?= date('d.m.y H:i', strtotime($log['Zeitpunkt'])) ?></td>
                 <td><?= htmlspecialchars($log['Feldname']) ?></td>
                 <td><?= htmlspecialchars($log['AlterWert']) ?></td>
                 <td><?= htmlspecialchars($log['NeuerWert']) ?></td>

--- a/public/vehicle_transfer.php
+++ b/public/vehicle_transfer.php
@@ -50,7 +50,7 @@ include __DIR__ . '/../includes/layout.php';
                 <?php if (!empty($transfers)): ?>
                     <?php foreach ($transfers as $transfer): ?>
                         <tr>
-                            <td><?= htmlspecialchars(date('d.m.Y', strtotime($transfer['transfer_date']))) ?></td>
+                            <td><?= htmlspecialchars(date('d.m.y', strtotime($transfer['transfer_date']))) ?></td>
                             <td><?= htmlspecialchars($transfer['fahrer_vorname'] . ' ' . $transfer['fahrer_nachname']) ?></td>
                             <td><?= htmlspecialchars($transfer['konzession'] . ' - ' . $transfer['marke'] . ' ' . $transfer['modell']) ?></td>
                             <td><?= htmlspecialchars($transfer['kilometerstand'] ?? 'Kein Eintrag') ?></td>

--- a/public/versand.php
+++ b/public/versand.php
@@ -21,7 +21,7 @@ define('LOGFILE', __DIR__ . '/schulung/versand.log');
  * @param int    $id              Teilnehmer‑ID
  * @param string $vorname         Vorname
  * @param string $email           Empfängeradresse
- * @param string $praxistagdatum  Termin im Format d.m.Y (wird hier zurückgewandelt)
+ * @param string $praxistagdatum  Termin im Format dd.mm.yy (wird hier zurückgewandelt)
  * @return bool  true bei Erfolg
  */
  
@@ -32,7 +32,7 @@ function sendInvitation($id, $vorname, $email, $praxistagdatum) {
 	/* ---------------------------------------------------------------------
 	1) Termin in DateTime wandeln
 	------------------------------------------------------------------ */
-    $dateObj = DateTime::createFromFormat('d.m.Y', $praxistagdatum);
+    $dateObj = DateTime::createFromFormat('d.m.y', $praxistagdatum);
     if (!$dateObj) {
         logMessage("Ungültiges Datumsformat: $praxistagdatum", LOGFILE);
         return false;
@@ -166,11 +166,11 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
             $email = $teilnehmer['email'];
             $praxistagdatum = $teilnehmer['schulungstermin'];
 
-            // Datum ins Format dd.mm.YYYY umwandeln
+            // Datum ins Format dd.mm.yy umwandeln
             if (!empty($praxistagdatum)) {
                 $date = DateTime::createFromFormat('Y-m-d', $praxistagdatum);
                 if ($date) {
-                    $praxistagdatum = $date->format('d.m.Y');
+                    $praxistagdatum = $date->format('d.m.y');
                 }
             }
 

--- a/public/xrechnung_pdf.php
+++ b/public/xrechnung_pdf.php
@@ -47,7 +47,7 @@ $pdf->AddPage();
 $pdf->SetFont('Arial', 'B', 16);
 $pdf->Cell(0, 10, "Rechnung: $invoiceId", 0, 1, 'C');
 $pdf->SetFont('Arial', '', 12);
-$pdf->Cell(0, 10, "Rechnungsdatum: " . date('d.m.Y', strtotime($issueDate)), 0, 1, 'C');
+$pdf->Cell(0, 10, "Rechnungsdatum: " . date('d.m.y', strtotime($issueDate)), 0, 1, 'C');
 $pdf->Ln(10);
 
 // Positionen

--- a/public/zentrale_dashboard.php
+++ b/public/zentrale_dashboard.php
@@ -264,9 +264,9 @@ include __DIR__ . '/../includes/layout.php';
 							Mitarbeiter: 
 							<?php echo htmlspecialchars($absence['employee_lastname'] . ', ' . $absence['employee_firstname']); ?><br>
 							Zeitraum: 
-							<?php echo date('d.m.Y', strtotime($absence['startdatum'])); ?>
+							<?php echo date('d.m.y', strtotime($absence['startdatum'])); ?>
 							bis 
-							<?php echo date('d.m.Y', strtotime($absence['enddatum'])); ?><br>
+							<?php echo date('d.m.y', strtotime($absence['enddatum'])); ?><br>
 							Grund: 
 							<?php echo htmlspecialchars($absence['typ']); ?><br>
 							<button onclick="markAsRead(<?php echo $absence['abwesenheit_id']; ?>)">
@@ -356,8 +356,8 @@ include __DIR__ . '/../includes/layout.php';
 					?>
 					<li>
 						<?php echo htmlspecialchars($vacation['vorname'] . ' ' . $vacation['nachname']); ?>: 
-						<?php echo date('d.m.Y', strtotime($vacation['startdatum'])); ?> bis 
-						<?php echo date('d.m.Y', strtotime($vacation['enddatum'])); ?> 
+						<?php echo date('d.m.y', strtotime($vacation['startdatum'])); ?> bis 
+						<?php echo date('d.m.y', strtotime($vacation['enddatum'])); ?> 
 						(<?php echo $workdays; ?> Tage)
 					</li>
 				<?php endforeach; ?>


### PR DESCRIPTION
## Summary
- format user-facing day-month-year values with two-digit years across dashboards, exports, and reports
- align email and PDF generation helpers with the new dd.mm.yy display convention, including parsing logic and documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c8389794832bb2e90edd03c51aba