### PR TITLE
Limit Schulungsstatus-Abfrage auf offene Teilnehmer

### DIFF
--- a/public/schulung/abfrage_status_schulung.php
+++ b/public/schulung/abfrage_status_schulung.php
@@ -34,8 +34,8 @@ if (!$api_key) {
     exit;
 }
 
-// Teilnehmer laden
-$stmt = $pdo->query("SELECT id, email FROM schulungsteilnehmer WHERE email IS NOT NULL");
+// Teilnehmer laden – nur jene ohne bereits hinterlegten Status abfragen
+$stmt = $pdo->query("SELECT id, email FROM schulungsteilnehmer WHERE email IS NOT NULL AND abschlusstest_bestanden IS NULL");
 $teilnehmer = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $erfolge = 0;


### PR DESCRIPTION
## Summary
- filter die Schulungsstatus-Abfrage auf Teilnehmer ohne hinterlegten Abschlusstest-Status, um doppelte Anfragen zu vermeiden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cab64304832bb9c53a5590762b42