### PR TITLE
Enable masonry layout for dashboard widgets

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1238,6 +1238,8 @@ button:hover {
     gap: 1.75rem;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     align-items: start;
+    grid-auto-rows: 12px;
+    grid-auto-flow: dense;
 }
 
 @media (min-width: 992px) {

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -645,6 +645,8 @@ include '../includes/layout.php';
             </section>
         </main>
     </div>
+        <script src="js/dashboard-masonry.js"></script>
+
         <script>
                 document.addEventListener("DOMContentLoaded", () => {
                         const greetingMessage = "<?php echo $greeting_message; ?>";

--- a/public/js/dashboard-masonry.js
+++ b/public/js/dashboard-masonry.js
@@ -1,0 +1,66 @@
+(function () {
+    'use strict';
+
+    const initializeMasonry = () => {
+        const grid = document.querySelector('.dashboard-main');
+        if (!grid) {
+            return;
+        }
+
+        const resizeCard = (card) => {
+            if (!card) {
+                return;
+            }
+
+            const gridStyles = window.getComputedStyle(grid);
+            const rowHeight = parseFloat(gridStyles.getPropertyValue('grid-auto-rows')) || 1;
+            const rowGap = parseFloat(gridStyles.getPropertyValue('row-gap')) || 0;
+            const body = card.querySelector('.card-body') || card;
+            const contentHeight = body.getBoundingClientRect().height;
+            const span = Math.max(1, Math.ceil((contentHeight + rowGap) / (rowHeight + rowGap)));
+
+            card.style.gridRowEnd = `span ${span}`;
+        };
+
+        const resizeAll = () => {
+            const cards = grid.querySelectorAll('.widget.card');
+            if (!cards.length) {
+                return;
+            }
+
+            cards.forEach((card) => resizeCard(card));
+        };
+
+        // Debounced resize for performance
+        let resizeTimer;
+        window.addEventListener('resize', () => {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(resizeAll, 150);
+        });
+
+        // Recalculate when fonts/images change dimensions
+        const images = grid.querySelectorAll('img');
+        images.forEach((img) => {
+            if (img.complete) {
+                const card = img.closest('.widget.card');
+                resizeCard(card);
+            } else {
+                img.addEventListener('load', () => {
+                    const card = img.closest('.widget.card');
+                    resizeCard(card);
+                });
+            }
+        });
+
+        const observer = new MutationObserver(() => resizeAll());
+        observer.observe(grid, { childList: true, subtree: true });
+
+        resizeAll();
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializeMasonry);
+    } else {
+        initializeMasonry();
+    }
+})();


### PR DESCRIPTION
## Summary
- adjust the dashboard grid to use dense auto-rows so cards can fill vertical gaps
- add a masonry helper script that calculates the necessary row spans per widget
- load the new script on the dashboard page to activate the layout

## Testing
- php -S 0.0.0.0:8000 -t public

------
https://chatgpt.com/codex/tasks/task_e_68e4f2e0a4f0832bae52154923213faf