### PR TITLE
Add top margin spacing for dashboard widgets

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -948,6 +948,7 @@ nav {
 
 .widget {
     background-color: white;
+    margin-top: 12px;
     margin-bottom: 20px;
     padding: 20px;
     border-radius: 10px;


### PR DESCRIPTION
## Summary
- add a consistent 12px top margin to dashboard widgets to prevent overlap with preceding elements

## Testing
- php -S 0.0.0.0:8000 -t public

------
https://chatgpt.com/codex/tasks/task_e_68e51e25fd14832b84f4574d1341ac08