### PR TITLE
Refactor driver access and revenue utilities

### DIFF
--- a/includes/driver_helpers.php
+++ b/includes/driver_helpers.php
@@ -1,0 +1,74 @@
+<?php
+
+if (!function_exists('driverHasRole')) {
+    /**
+     * Prüft, ob der aktuell eingeloggte Benutzer über die angegebene Rolle verfügt.
+     */
+    function driverHasRole(string $role): bool
+    {
+        $normalizedRole = strtolower($role);
+        $primaryRole = strtolower($_SESSION['user_role'] ?? '');
+
+        if ($primaryRole === $normalizedRole) {
+            return true;
+        }
+
+        $secondaryRoles = array_map('strtolower', $_SESSION['sekundarRolle'] ?? []);
+        return in_array($normalizedRole, $secondaryRoles, true);
+    }
+}
+
+if (!function_exists('ensureDriverAccess')) {
+    /**
+     * Stellt sicher, dass der aktuelle Benutzer als Fahrer angemeldet ist.
+     * Bei fehlender Berechtigung erfolgt eine Weiterleitung zur Login- bzw. Startseite.
+     */
+    function ensureDriverAccess(): void
+    {
+        $_SESSION['rolle'] = 'Fahrer';
+
+        if (!isset($_SESSION['user_id'])) {
+            header('Location: ../login.php');
+            exit();
+        }
+
+        if (!driverHasRole('fahrer')) {
+            header('Location: ../index.php');
+            exit();
+        }
+    }
+}
+
+if (!function_exists('requireDriverId')) {
+    /**
+     * Gibt die Fahrer-ID des aktuell eingeloggten Benutzers zurück und stellt sicher,
+     * dass der Benutzer über die Fahrer-Rolle verfügt.
+     */
+    function requireDriverId(): int
+    {
+        ensureDriverAccess();
+        return (int) $_SESSION['user_id'];
+    }
+}
+
+if (!function_exists('fetchDriverProfile')) {
+    /**
+     * Lädt das Fahrer-Profil aus der Datenbank.
+     *
+     * @throws RuntimeException Wenn kein Fahrerprofil gefunden wurde.
+     */
+    function fetchDriverProfile(PDO $pdo, ?int $fahrerId = null): array
+    {
+        $fahrerId = $fahrerId ?? requireDriverId();
+
+        $stmt = $pdo->prepare('SELECT * FROM Fahrer WHERE FahrerID = ?');
+        $stmt->execute([$fahrerId]);
+        $fahrer = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$fahrer) {
+            throw new RuntimeException('Fahrerprofil wurde nicht gefunden.');
+        }
+
+        return $fahrer;
+    }
+}

--- a/includes/umsatz_repository.php
+++ b/includes/umsatz_repository.php
@@ -1,0 +1,229 @@
+<?php
+
+class UmsatzRepository
+{
+    private const MUTABLE_FIELDS = [
+        'TaxameterUmsatz',
+        'OhneTaxameter',
+        'Kartenzahlung',
+        'Rechnungsfahrten',
+        'Krankenfahrten',
+        'Gutscheine',
+        'Alita',
+        'TankenWaschen',
+        'SonstigeAusgaben',
+        'Notiz',
+    ];
+
+    private const DEFAULT_VALUES = [
+        'Notiz' => null,
+    ];
+
+    public function __construct(private PDO $pdo)
+    {
+    }
+
+    public function getByDriverAndDate(int $fahrerId, string $datum): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT * FROM Umsatz WHERE FahrerID = ? AND Datum = ?'
+        );
+        $stmt->execute([$fahrerId, $datum]);
+
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $result !== false ? $result : null;
+    }
+
+    public function getByDriverAndRange(int $fahrerId, string $startDate, string $endDate): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT Datum, TaxameterUmsatz, OhneTaxameter, Kartenzahlung, Rechnungsfahrten, Krankenfahrten, ' .
+            'Gutscheine, Alita, TankenWaschen, SonstigeAusgaben, Notiz, Abgerechnet ' .
+            'FROM Umsatz WHERE FahrerID = ? AND Datum BETWEEN ? AND ? ORDER BY Datum ASC'
+        );
+        $stmt->execute([$fahrerId, $startDate, $endDate]);
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function create(int $fahrerId, array $data): void
+    {
+        $placeholders = implode(', ', self::MUTABLE_FIELDS);
+        $valuesPlaceholders = implode(', ', array_fill(0, count(self::MUTABLE_FIELDS), '?'));
+
+        $stmt = $this->pdo->prepare(
+            sprintf(
+                'INSERT INTO Umsatz (FahrerID, Datum, %s) VALUES (?, ?, %s)',
+                $placeholders,
+                $valuesPlaceholders
+            )
+        );
+
+        $params = [$fahrerId, $data['Datum']];
+        foreach (self::MUTABLE_FIELDS as $field) {
+            if (array_key_exists($field, $data)) {
+                $params[] = $data[$field];
+            } else {
+                $params[] = self::DEFAULT_VALUES[$field] ?? 0;
+            }
+        }
+
+        $stmt->execute($params);
+    }
+
+    public function update(int $fahrerId, string $datum, array $data): void
+    {
+        $fields = [];
+        $params = [];
+
+        foreach (self::MUTABLE_FIELDS as $field) {
+            if (array_key_exists($field, $data)) {
+                $fields[] = sprintf('%s = ?', $field);
+                $params[] = $data[$field];
+            }
+        }
+
+        if (empty($fields)) {
+            return;
+        }
+
+        $params[] = $fahrerId;
+        $params[] = $datum;
+
+        $sql = sprintf(
+            'UPDATE Umsatz SET %s WHERE FahrerID = ? AND Datum = ?',
+            implode(', ', $fields)
+        );
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+    }
+
+    public function delete(int $fahrerId, string $datum): bool
+    {
+        $stmt = $this->pdo->prepare(
+            'DELETE FROM Umsatz WHERE FahrerID = ? AND Datum = ?'
+        );
+
+        return $stmt->execute([$fahrerId, $datum]);
+    }
+
+    public function findOpenShiftDates(int $fahrerId): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT DISTINCT DATE(sfa.anmeldung) AS offenes_datum
+             FROM sync_fahreranmeldung sfa
+             JOIN Fahrer f
+               ON sfa.fahrer = f.Fahrernummer OR sfa.fahrer = f.fms_alias
+             WHERE f.FahrerID = :fahrer_id
+               AND DATE(sfa.anmeldung) NOT IN (
+                   SELECT DATE(Datum) FROM Umsatz WHERE FahrerID = :fahrer_id
+               )
+             ORDER BY offenes_datum DESC'
+        );
+
+        $stmt->execute(['fahrer_id' => $fahrerId]);
+
+        return $stmt->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    public static function calculateBargeld(array $entry): float
+    {
+        $income = (float) ($entry['TaxameterUmsatz'] ?? 0) + (float) ($entry['OhneTaxameter'] ?? 0);
+        $expenses = (float) ($entry['Kartenzahlung'] ?? 0)
+            + (float) ($entry['Rechnungsfahrten'] ?? 0)
+            + (float) ($entry['Krankenfahrten'] ?? 0)
+            + (float) ($entry['Gutscheine'] ?? 0)
+            + (float) ($entry['Alita'] ?? 0)
+            + (float) ($entry['TankenWaschen'] ?? 0)
+            + (float) ($entry['SonstigeAusgaben'] ?? 0);
+
+        return $income - $expenses;
+    }
+
+    public static function calculateTotals(array $entries): array
+    {
+        $umsatz = 0.0;
+        $bargeld = 0.0;
+
+        foreach ($entries as $entry) {
+            $umsatz += (float) ($entry['TaxameterUmsatz'] ?? 0) + (float) ($entry['OhneTaxameter'] ?? 0);
+            $bargeld += self::calculateBargeld($entry);
+        }
+
+        return [
+            'umsatz' => $umsatz,
+            'bargeld' => $bargeld,
+        ];
+    }
+
+    public static function aggregateByDate(array $entries): array
+    {
+        $totals = [];
+
+        foreach ($entries as $entry) {
+            $dateKey = substr($entry['Datum'], 0, 10);
+            $totals[$dateKey] = ($totals[$dateKey] ?? 0)
+                + (float) ($entry['TaxameterUmsatz'] ?? 0)
+                + (float) ($entry['OhneTaxameter'] ?? 0);
+        }
+
+        ksort($totals);
+
+        $result = [];
+        foreach ($totals as $date => $sum) {
+            $result[] = [
+                'Datum' => $date,
+                'GesamtUmsatz' => $sum,
+            ];
+        }
+
+        return $result;
+    }
+
+    public static function aggregateByType(array $entries): array
+    {
+        $totals = [
+            'Barzahlung' => 0.0,
+            'Kartenzahlung' => 0.0,
+            'Rechnungsfahrten' => 0.0,
+            'Krankenfahrten' => 0.0,
+            'Gutscheine' => 0.0,
+            'Alita' => 0.0,
+        ];
+
+        foreach ($entries as $entry) {
+            $income = (float) ($entry['TaxameterUmsatz'] ?? 0) + (float) ($entry['OhneTaxameter'] ?? 0);
+            $nonCash = (float) ($entry['Kartenzahlung'] ?? 0)
+                + (float) ($entry['Rechnungsfahrten'] ?? 0)
+                + (float) ($entry['Krankenfahrten'] ?? 0)
+                + (float) ($entry['Gutscheine'] ?? 0)
+                + (float) ($entry['Alita'] ?? 0);
+
+            $totals['Barzahlung'] += $income - $nonCash;
+            $totals['Kartenzahlung'] += (float) ($entry['Kartenzahlung'] ?? 0);
+            $totals['Rechnungsfahrten'] += (float) ($entry['Rechnungsfahrten'] ?? 0);
+            $totals['Krankenfahrten'] += (float) ($entry['Krankenfahrten'] ?? 0);
+            $totals['Gutscheine'] += (float) ($entry['Gutscheine'] ?? 0);
+            $totals['Alita'] += (float) ($entry['Alita'] ?? 0);
+        }
+
+        return $totals;
+    }
+
+    public static function aggregateExpenses(array $entries): array
+    {
+        $totals = [
+            'Tanken und Waschen' => 0.0,
+            'Sonstige Ausgaben' => 0.0,
+        ];
+
+        foreach ($entries as $entry) {
+            $totals['Tanken und Waschen'] += (float) ($entry['TankenWaschen'] ?? 0);
+            $totals['Sonstige Ausgaben'] += (float) ($entry['SonstigeAusgaben'] ?? 0);
+        }
+
+        return $totals;
+    }
+}

--- a/public/driver/delete_entry.php
+++ b/public/driver/delete_entry.php
@@ -1,32 +1,26 @@
 <?php
 require_once '../../includes/bootstrap.php'; // Lädt Authentifizierung und Datenbankverbindung
+require_once '../../includes/driver_helpers.php';
+require_once '../../includes/umsatz_repository.php';
 
-// Rolle für diese Route festlegen (einfachste Variante)
-$_SESSION['rolle'] = 'Fahrer';
-
-// Überprüfung, ob der Benutzer eingeloggt ist
-if (!isset($_SESSION['user_id'])) {
-    die('Fehler: Keine gültige Session. Bitte erneut anmelden.');
+try {
+    $fahrer_id = requireDriverId();
+} catch (RuntimeException $e) {
+    die($e->getMessage());
 }
+
+$umsatzRepository = new UmsatzRepository($pdo);
 
 // Überprüfung, ob das Datum übergeben wurde
 if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['datum'])) {
     $datum = $_GET['datum'];
-    $fahrer_id = $_SESSION['user_id']; // Fahrer-ID aus der Session
 
     // Validierung des Datums
     if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $datum)) { // Prüft auf das Format YYYY-MM-DD
         die('Ungültiges Datumsformat.');
     }
 
-    // Überprüfung, ob der Eintrag existiert und zur Fahrer-ID gehört
-    $stmt = $pdo->prepare("
-        SELECT * 
-        FROM Umsatz 
-        WHERE Datum = ? AND FahrerID = ?
-    ");
-    $stmt->execute([$datum, $fahrer_id]);
-    $eintrag = $stmt->fetch(PDO::FETCH_ASSOC);
+    $eintrag = $umsatzRepository->getByDriverAndDate($fahrer_id, $datum);
 
     if (!$eintrag) {
         die('Eintrag nicht gefunden oder keine Berechtigung, diesen Eintrag zu löschen.');
@@ -34,11 +28,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['datum'])) {
 
     // Eintrag löschen
     try {
-        $stmt = $pdo->prepare("
-            DELETE FROM Umsatz 
-            WHERE Datum = ? AND FahrerID = ?
-        ");
-        $stmt->execute([$datum, $fahrer_id]);
+        $umsatzRepository->delete($fahrer_id, $datum);
 
         // Weiterleitung nach erfolgreichem Löschen
         header('Location: dashboard.php?success=Eintrag gelöscht');

--- a/public/driver/fahrzeug.php
+++ b/public/driver/fahrzeug.php
@@ -1,22 +1,18 @@
 <?php
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
-	
+
 require_once '../../includes/bootstrap.php'; // Datenbankverbindung und Authentifizierung
+require_once '../../includes/driver_helpers.php';
 
-// Rolle für diese Route festlegen (einfachste Variante)
-$_SESSION['rolle'] = 'Fahrer';
-
-if (!isset($_SESSION['user_id'])) {
-    die('Fehler: Keine gültige Session. Bitte erneut anmelden.');
+try {
+    $fahrer_id = requireDriverId();
+    $fahrer = fetchDriverProfile($pdo, $fahrer_id);
+} catch (RuntimeException $e) {
+    die($e->getMessage());
 }
-$fahrer_id = $_SESSION['user_id'];
 
-// Fahrername abrufen
-$stmtFahrer = $pdo->prepare("SELECT Vorname, Nachname FROM Fahrer WHERE FahrerID = :id");
-$stmtFahrer->execute(['id' => $fahrer_id]);
-$fahrer = $stmtFahrer->fetch(PDO::FETCH_ASSOC);
-$fahrer_name = $fahrer ? $fahrer['Vorname'] . ' ' . $fahrer['Nachname'] : 'Unbekannter Fahrer';
+$fahrer_name = $fahrer['Vorname'] . ' ' . $fahrer['Nachname'];
 
 // Verarbeitung der Inspektionsmeldung
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['inspektion_melden'])) {

--- a/public/driver/personal.php
+++ b/public/driver/personal.php
@@ -4,20 +4,13 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 require_once '../../includes/bootstrap.php'; // Verbindung und Authentifizierung
+require_once '../../includes/driver_helpers.php';
 
-// Rolle für diese Route festlegen (einfachste Variante)
-$_SESSION['rolle'] = 'Fahrer';
-
-// Session prüfen
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
+try {
+    $fahrer_id = requireDriverId();
+} catch (RuntimeException $e) {
+    die($e->getMessage());
 }
-
-if (!isset($_SESSION['user_id'])) {
-    die('Fehler: Keine gültige Session.');
-}
-
-$fahrer_id = $_SESSION['user_id'];
 
 // Persönliche Daten abrufen
 try {

--- a/public/driver/process_urlaub_antrag.php
+++ b/public/driver/process_urlaub_antrag.php
@@ -3,19 +3,15 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-session_start();
-
-// Rolle für diese Route festlegen (einfachste Variante)
-$_SESSION['rolle'] = 'Fahrer';
-
-require_once '../../includes/db.php'; // Passe den Pfad an, falls nötig.
+require_once '../../includes/bootstrap.php';
+require_once '../../includes/driver_helpers.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // Sicherstellen, dass der Fahrer eingeloggt ist
-    if (!isset($_SESSION['user_id'])) {
+    try {
+        $fahrer_id = requireDriverId();
+    } catch (RuntimeException $e) {
         die('Nicht autorisiert.');
     }
-    $fahrer_id = $_SESSION['user_id'];
 
     // Daten aus dem Formular sammeln
     $startdatum = $_POST['startdatum'] ?? null;

--- a/public/driver/send_message.php
+++ b/public/driver/send_message.php
@@ -1,15 +1,12 @@
 <?php
 require_once '../../includes/bootstrap.php';
+require_once '../../includes/driver_helpers.php';
 
-// Rolle für diese Route festlegen (einfachste Variante)
-$_SESSION['rolle'] = 'Fahrer';
-
-if (!isDriver()) {
-    header('Location: ../index.php');
-    exit;
+try {
+    $driverId = requireDriverId();
+} catch (RuntimeException $e) {
+    die($e->getMessage());
 }
-
-$driverId = $_SESSION['user_id'];
 
 // Permitted recipients for this driver
 $permStmt = $pdo->prepare(

--- a/public/js/driver-cash-calculator.js
+++ b/public/js/driver-cash-calculator.js
@@ -1,0 +1,108 @@
+(function (window, document) {
+    'use strict';
+
+    function normalizeId(field) {
+        return field.charAt(0) === '#' ? field.substring(1) : field;
+    }
+
+    function getElement(id) {
+        return document.getElementById(id);
+    }
+
+    window.DriverCashCalculator = {
+        init(options) {
+            const config = Object.assign({
+                incomeFields: [],
+                expenseFields: [],
+                outputField: null,
+                onUpdate: null,
+            }, options || {});
+
+            const incomeIds = config.incomeFields.map(normalizeId);
+            const expenseIds = config.expenseFields.map(normalizeId);
+            const outputSelector = config.outputField;
+            const listeners = {};
+            let lastState = {
+                total: 0,
+                income: 0,
+                expenses: 0,
+                values: {},
+            };
+
+            function update() {
+                const values = {};
+                let incomeSum = 0;
+                let expenseSum = 0;
+
+                incomeIds.forEach((id) => {
+                    const element = getElement(id);
+                    if (!element) {
+                        return;
+                    }
+
+                    const value = parseFloat(element.value) || 0;
+                    values[id] = value;
+                    incomeSum += value;
+                });
+
+                expenseIds.forEach((id) => {
+                    const element = getElement(id);
+                    if (!element) {
+                        return;
+                    }
+
+                    const value = parseFloat(element.value) || 0;
+                    values[id] = value;
+                    expenseSum += value;
+                });
+
+                const total = incomeSum - expenseSum;
+
+                if (outputSelector) {
+                    const outputElement = typeof outputSelector === 'string'
+                        ? document.querySelector(outputSelector)
+                        : outputSelector;
+
+                    if (outputElement) {
+                        outputElement.value = total.toFixed(2);
+                    }
+                }
+
+                lastState = {
+                    total,
+                    income: incomeSum,
+                    expenses: expenseSum,
+                    values,
+                    elements: listeners,
+                };
+
+                if (typeof config.onUpdate === 'function') {
+                    config.onUpdate(lastState);
+                }
+            }
+
+            const attachFields = (ids) => {
+                ids.forEach((id) => {
+                    const element = getElement(id);
+                    if (!element) {
+                        return;
+                    }
+
+                    listeners[id] = element;
+                    element.addEventListener('input', update);
+                });
+            };
+
+            attachFields(incomeIds);
+            attachFields(expenseIds);
+            update();
+
+            return {
+                recalc: update,
+                getTotals() {
+                    return Object.assign({}, lastState);
+                },
+            };
+        },
+    };
+}(window, document));


### PR DESCRIPTION
## Summary
- add reusable driver access helper and wire it into driver pages
- introduce an Umsatz repository for CRUD and aggregate helpers powering dashboard and statistics
- extract a shared cash calculator script and reuse it across driver revenue forms

## Testing
- php -l includes/driver_helpers.php
- php -l public/driver/umsatz_erfassen.php

------
https://chatgpt.com/codex/tasks/task_e_68e51d52d248832b936e9255cb233f0e