### PR TITLE
Improve message inbox auto-refresh

### DIFF
--- a/public/api/conversations.php
+++ b/public/api/conversations.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../includes/config.php';
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../app/Models/Message.php';
+
+use App\Models\Message;
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthenticated']);
+    exit;
+}
+
+$userId = (int) $_SESSION['user_id'];
+$conversations = Message::getConversationsByUser($userId);
+
+echo json_encode(array_map(static function (array $conversation): array {
+    return [
+        'id' => (int) $conversation['id'],
+        'subject' => $conversation['subject'],
+        'body' => $conversation['body'],
+        'created_at' => $conversation['created_at'],
+        'other_id' => (int) $conversation['other_id'],
+        'other_name' => $conversation['other_name'],
+    ];
+}, $conversations));

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -86,6 +86,10 @@
     background-color: #f0f0f0;
 }
 
+.conversation-item.active {
+    background-color: #e6f0ff;
+}
+
 
 .conversation-panel {
     flex: 1;

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -1,13 +1,20 @@
 document.addEventListener('DOMContentLoaded', function () {
-  var items = document.querySelectorAll('.conversation-item');
   var content = document.getElementById('conversation-content');
+  var conversationList = document.querySelector('.conversation-list');
   var chatForm = document.getElementById('chat-form');
   var recipientInput = document.getElementById('chat-recipient-id');
   var subjectInput = document.getElementById('chat-subject');
   var bodyInput = document.getElementById('chat-body');
   var notificationPollInterval = null;
+  var conversationPollInterval = null;
+  var conversationListPollInterval = null;
   var knownUnreadMessageIds = new Set();
   var unreadInitialized = false;
+  var currentOtherId = null;
+  var activeConversationItem = null;
+  var isConversationPolling = false;
+  var conversationSnapshots = {};
+  var conversationListSnapshot = '';
 
   function escapeHtml(str) {
     return str
@@ -16,35 +23,285 @@ document.addEventListener('DOMContentLoaded', function () {
       .replace(/>/g, '&gt;');
   }
 
-  items.forEach(function (item) {
-    item.addEventListener('click', function () {
-      var otherId = parseInt(item.getAttribute('data-other-id'), 10);
-      fetch('/api/messages.php?other_id=' + encodeURIComponent(otherId))
-        .then(function (res) { return res.json(); })
-        .then(function (messages) {
-          var html = '';
-          messages.forEach(function (msg) {
-            var cls = (msg.sender_id === otherId) ? 'received' : 'sent';
-            html += '<div class="message ' + cls + '">';
-            html += '<p class="message-header"><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>';
-            if (msg.subject) {
-              html += '<p class="message-subject"><span>Betreff:</span> ' + escapeHtml(msg.subject) + '</p>';
-            }
-            html += '<p class="message-body">' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>';
-            if (msg.read_at) {
-              html += '<p class="message-meta">Gelesen am ' + escapeHtml(msg.read_at) + '</p>';
-            }
-            html += '</div>';
-          });
-          content.innerHTML = html;
-        });
-      recipientInput.value = otherId;
-      subjectInput.value = item.getAttribute('data-subject');
-    });
-  });
+  function truncatePreview(text) {
+    var cleaned = text.replace(/\s+/g, ' ').trim();
+    if (cleaned.length <= 40) {
+      return cleaned;
+    }
+    return cleaned.slice(0, 37) + '…';
+  }
 
-  if (items.length > 0) {
-    items[0].click();
+  function isScrolledToBottom() {
+    if (!content) {
+      return false;
+    }
+    return Math.abs(content.scrollHeight - content.clientHeight - content.scrollTop) < 5;
+  }
+
+  function scrollConversationToBottom() {
+    if (!content) {
+      return;
+    }
+    content.scrollTop = content.scrollHeight;
+  }
+
+  function setActiveConversationItem(item) {
+    if (activeConversationItem) {
+      activeConversationItem.classList.remove('active');
+    }
+    activeConversationItem = item || null;
+    if (activeConversationItem) {
+      activeConversationItem.classList.add('active');
+    }
+  }
+
+  function renderConversation(messages, otherId, options) {
+    if (!content || !Array.isArray(messages)) {
+      return;
+    }
+
+    var snapshot = messages
+      .map(function (msg) { return msg.id + ':' + (msg.read_at || ''); })
+      .join('|');
+
+    var forceRender = options && options.forceRender;
+    if (!forceRender && conversationSnapshots[otherId] === snapshot) {
+      return;
+    }
+
+    conversationSnapshots[otherId] = snapshot;
+
+    var wasAtBottom = false;
+    if (options && options.maintainScrollPosition) {
+      wasAtBottom = isScrolledToBottom();
+    }
+
+    var html = '';
+    messages.forEach(function (msg) {
+      var cls = (msg.sender_id === otherId) ? 'received' : 'sent';
+      html += '<div class="message ' + cls + '">';
+      html += '<p class="message-header"><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>';
+      if (msg.subject) {
+        html += '<p class="message-subject"><span>Betreff:</span> ' + escapeHtml(msg.subject) + '</p>';
+      }
+      html += '<p class="message-body">' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>';
+      if (msg.read_at) {
+        html += '<p class="message-meta">Gelesen am ' + escapeHtml(msg.read_at) + '</p>';
+      }
+      html += '</div>';
+    });
+    content.innerHTML = html;
+
+    if (options && options.updateListPreview) {
+      updateConversationPreview(otherId, messages);
+    }
+
+    var shouldScrollToBottom = Boolean(options && options.scrollToBottom);
+    if (!shouldScrollToBottom && options && options.maintainScrollPosition && wasAtBottom) {
+      shouldScrollToBottom = true;
+    }
+
+    if (shouldScrollToBottom) {
+      scrollConversationToBottom();
+    }
+  }
+
+  function fetchConversation(otherId, options) {
+    if (!otherId) {
+      return Promise.resolve();
+    }
+
+    return fetch('/api/messages.php?other_id=' + encodeURIComponent(otherId))
+      .then(function (res) { return res.json(); })
+      .then(function (messages) {
+        renderConversation(messages, otherId, options || {});
+      })
+      .catch(function (err) {
+        console.error('Fehler beim Laden der Unterhaltung:', err);
+      });
+  }
+
+  function updateConversationPreview(otherId, messages) {
+    if (!conversationList || !Array.isArray(messages) || messages.length === 0) {
+      return;
+    }
+
+    var item = conversationList.querySelector('.conversation-item[data-other-id="' + otherId + '"]');
+    if (!item) {
+      return;
+    }
+
+    var lastMessage = messages[messages.length - 1];
+    if (lastMessage.subject !== undefined) {
+      item.setAttribute('data-subject', lastMessage.subject || '');
+    }
+
+    var preview = item.querySelector('.preview');
+    if (preview) {
+      preview.textContent = truncatePreview(lastMessage.body || '');
+    }
+  }
+
+  function buildConversationItem(conv) {
+    var item = document.createElement('div');
+    item.className = 'card conversation-item';
+    item.setAttribute('data-other-id', conv.other_id);
+    item.setAttribute('data-subject', conv.subject || '');
+
+    var nameEl = document.createElement('strong');
+    nameEl.textContent = conv.other_name || '';
+    item.appendChild(nameEl);
+    item.appendChild(document.createElement('br'));
+
+    var subjectEl = document.createElement('span');
+    subjectEl.textContent = conv.subject || '';
+    item.appendChild(subjectEl);
+    item.appendChild(document.createElement('br'));
+
+    var previewEl = document.createElement('span');
+    previewEl.className = 'preview';
+    previewEl.textContent = truncatePreview(conv.body || '');
+    item.appendChild(previewEl);
+
+    item.addEventListener('click', function () {
+      selectConversation(parseInt(conv.other_id, 10), item, { scrollToBottom: true, forceRender: true });
+    });
+
+    return item;
+  }
+
+  function rebuildConversationList(conversations) {
+    if (!conversationList) {
+      return;
+    }
+
+    var previousOtherId = currentOtherId;
+    conversationList.innerHTML = '';
+
+    var newActiveItem = null;
+
+    conversations.forEach(function (conv) {
+      var item = buildConversationItem(conv);
+      conversationList.appendChild(item);
+      if (previousOtherId !== null && parseInt(conv.other_id, 10) === previousOtherId) {
+        newActiveItem = item;
+      }
+    });
+
+    if (newActiveItem) {
+      setActiveConversationItem(newActiveItem);
+    } else if (previousOtherId !== null && conversations.length > 0) {
+      var firstItem = conversationList.querySelector('.conversation-item');
+      if (firstItem) {
+        selectConversation(parseInt(firstItem.getAttribute('data-other-id'), 10), firstItem, { scrollToBottom: false, forceRender: true });
+      }
+    } else if (previousOtherId === null && conversations.length > 0) {
+      var initialItem = conversationList.querySelector('.conversation-item');
+      if (initialItem) {
+        selectConversation(parseInt(initialItem.getAttribute('data-other-id'), 10), initialItem, { scrollToBottom: true, forceRender: true });
+      }
+    }
+  }
+
+  function refreshConversationList(force) {
+    if (!conversationList) {
+      return Promise.resolve();
+    }
+
+    return fetch('/api/conversations.php')
+      .then(function (res) { return res.json(); })
+      .then(function (conversations) {
+        if (!Array.isArray(conversations)) {
+          return;
+        }
+
+        var snapshot = JSON.stringify(conversations.map(function (conv) {
+          return [conv.other_id, conv.id, conv.created_at].join(':');
+        }));
+
+        if (!force && snapshot === conversationListSnapshot) {
+          return;
+        }
+
+        conversationListSnapshot = snapshot;
+        rebuildConversationList(conversations);
+      })
+      .catch(function (err) {
+        console.error('Fehler beim Aktualisieren der Unterhaltungsliste:', err);
+      });
+  }
+
+  function selectConversation(otherId, item, options) {
+    if (!otherId || !item) {
+      return;
+    }
+
+    currentOtherId = otherId;
+    setActiveConversationItem(item);
+
+    if (recipientInput) {
+      recipientInput.value = otherId;
+    }
+    if (subjectInput) {
+      subjectInput.value = item.getAttribute('data-subject') || '';
+    }
+
+    var renderOptions = {
+      forceRender: options && options.forceRender,
+      scrollToBottom: options && options.scrollToBottom,
+      maintainScrollPosition: options && options.maintainScrollPosition,
+      updateListPreview: true
+    };
+
+    fetchConversation(otherId, renderOptions).then(function () {
+      ensureConversationPolling();
+    });
+  }
+
+  function ensureConversationPolling() {
+    if (conversationPollInterval !== null) {
+      return;
+    }
+
+    conversationPollInterval = setInterval(function () {
+      if (isConversationPolling || currentOtherId === null) {
+        return;
+      }
+
+      isConversationPolling = true;
+      fetchConversation(currentOtherId, {
+        maintainScrollPosition: true,
+        updateListPreview: true
+      }).then(function () {
+        isConversationPolling = false;
+      });
+    }, 5000);
+  }
+
+  function ensureConversationListPolling() {
+    if (conversationListPollInterval !== null) {
+      return;
+    }
+
+    conversationListPollInterval = setInterval(function () {
+      refreshConversationList(false);
+    }, 15000);
+  }
+
+  if (conversationList) {
+    Array.prototype.forEach.call(conversationList.querySelectorAll('.conversation-item'), function (item, index) {
+      item.addEventListener('click', function () {
+        var otherId = parseInt(item.getAttribute('data-other-id'), 10);
+        selectConversation(otherId, item, { scrollToBottom: true, forceRender: true });
+      });
+
+      if (index === 0 && currentOtherId === null) {
+        var initialOtherId = parseInt(item.getAttribute('data-other-id'), 10);
+        selectConversation(initialOtherId, item, { scrollToBottom: true, forceRender: true });
+      }
+    });
+
+    ensureConversationListPolling();
   }
 
   function baselineUnreadMessages(messages) {
@@ -150,26 +407,25 @@ document.addEventListener('DOMContentLoaded', function () {
           }
           return res.json();
         })
-        .then(function (msg) {
-          if (msg && msg.error) {
-            console.error(msg.error);
+        .then(function (response) {
+          if (response && response.error) {
+            console.error(response.error);
             return;
           }
 
-          if (msg && msg.sender_name) {
-            var newMessageHtml = '<div class="message sent">';
-            newMessageHtml += '<p class="message-header"><strong>' + escapeHtml(msg.sender_name) + '</strong> am ' + escapeHtml(msg.created_at) + '</p>';
-            if (msg.subject) {
-              newMessageHtml += '<p class="message-subject"><span>Betreff:</span> ' + escapeHtml(msg.subject) + '</p>';
-            }
-            newMessageHtml += '<p class="message-body">' + escapeHtml(msg.body).replace(/\n/g, '<br>') + '</p>';
-            if (msg.read_at) {
-              newMessageHtml += '<p class="message-meta">Gelesen am ' + escapeHtml(msg.read_at) + '</p>';
-            }
-            newMessageHtml += '</div>';
-            content.insertAdjacentHTML('beforeend', newMessageHtml);
+          if (bodyInput) {
+            bodyInput.value = '';
           }
-          bodyInput.value = '';
+
+          if (currentOtherId !== null) {
+            fetchConversation(currentOtherId, {
+              forceRender: true,
+              scrollToBottom: true,
+              updateListPreview: true
+            });
+          }
+
+          refreshConversationList(true);
         })
         .catch(function (err) {
           console.error(err);


### PR DESCRIPTION
## Summary
- add an API endpoint to deliver the latest conversation overview for the inbox
- enhance the messages inbox JavaScript to reload conversations after sending and poll for updates
- highlight the active conversation item for better visual feedback

## Testing
- php -l public/api/conversations.php

------
https://chatgpt.com/codex/tasks/task_e_68e5f9e20148832bb966f7d53a41e01a