### PR TITLE
Add manual notification permission prompt to inbox

### DIFF
--- a/app/Views/messages/inbox.php
+++ b/app/Views/messages/inbox.php
@@ -3,8 +3,15 @@
 ?>
 <main>
     <h1>Nachrichten</h1>
-    <div style="text-align: right;">
-        <button class="btn btn-primary" onclick="openModal('composeModal')">Neue Nachricht</button>
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2" style="margin-bottom: 1rem;">
+        <div class="notification-permission">
+            <button type="button" class="btn btn-secondary" id="enable-notifications" style="display: none;">
+                Desktop-Benachrichtigungen aktivieren
+            </button>
+        </div>
+        <div style="text-align: right;">
+            <button class="btn btn-primary" onclick="openModal('composeModal')">Neue Nachricht</button>
+        </div>
     </div>
 
     <?php if (!empty($success)): ?>

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var subjectInput = document.getElementById('chat-subject');
   var bodyInput = document.getElementById('chat-body');
   var notificationPollInterval = null;
+  var notificationButton = document.getElementById('enable-notifications');
   var knownUnreadMessageIds = new Set();
   var unreadInitialized = false;
 
@@ -118,18 +119,56 @@ document.addEventListener('DOMContentLoaded', function () {
     }, 30000);
   }
 
-  if ('Notification' in window) {
+  function updateNotificationButtonState() {
+    if (!notificationButton) {
+      return;
+    }
+
+    if (!('Notification' in window)) {
+      notificationButton.style.display = 'inline-block';
+      notificationButton.disabled = true;
+      notificationButton.textContent = 'Desktop-Benachrichtigungen werden nicht unterstützt';
+      return;
+    }
+
     if (Notification.permission === 'granted') {
+      notificationButton.style.display = 'none';
       startNotificationPolling();
-    } else if (Notification.permission !== 'denied') {
+      return;
+    }
+
+    notificationButton.style.display = 'inline-block';
+
+    if (Notification.permission === 'denied') {
+      notificationButton.disabled = true;
+      notificationButton.textContent = 'Benachrichtigungen im Browser aktivieren';
+      notificationButton.title = 'Bitte aktivieren Sie Benachrichtigungen in den Browser-Einstellungen.';
+    } else {
+      notificationButton.disabled = false;
+      notificationButton.textContent = 'Desktop-Benachrichtigungen aktivieren';
+      notificationButton.removeAttribute('title');
+    }
+  }
+
+  if (notificationButton) {
+    notificationButton.addEventListener('click', function () {
+      if (!('Notification' in window)) {
+        return;
+      }
+
       Notification.requestPermission().then(function (permission) {
         if (permission === 'granted') {
           startNotificationPolling();
         }
+        updateNotificationButtonState();
       }).catch(function (err) {
         console.error('Benachrichtigungsberechtigung konnte nicht angefordert werden:', err);
       });
-    }
+    });
+
+    updateNotificationButtonState();
+  } else if ('Notification' in window && Notification.permission === 'granted') {
+    startNotificationPolling();
   }
 
   if (chatForm) {


### PR DESCRIPTION
## Summary
- add a desktop notification activation button to the inbox view so users can opt in explicitly
- adjust the messaging script to handle the activation button and only request permission on user interaction
- provide feedback states when notifications are unsupported or disabled in the browser

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5fa0f7914832b9481d49fab46ba0d