### PR TITLE
Handle missing burger menu on fines management page

### DIFF
--- a/public/fines_management.php
+++ b/public/fines_management.php
@@ -229,9 +229,15 @@ include __DIR__ . '/../includes/layout.php';
     </section>
     </main>
     <script>
-        document.querySelector('.burger-menu').addEventListener('click', () => {
-            document.querySelector('.nav-links').classList.toggle('active');
-        });
+        const burgerMenu = document.querySelector('.burger-menu');
+        if (burgerMenu) {
+            burgerMenu.addEventListener('click', () => {
+                const navLinks = document.querySelector('.nav-links');
+                if (navLinks) {
+                    navLinks.classList.toggle('active');
+                }
+            });
+        }
 
         const modal = document.getElementById("fineModal");
         const btn = document.getElementById("openModal");


### PR DESCRIPTION
## Summary
- guard the burger menu click handler on fines_management.php so the script continues when the burger toggle is absent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6263cf144832b823f507cbf303dc1