### PR TITLE
Add invitation history modal for training participants

### DIFF
--- a/migrations/2024090204_create_schulungseinladungen.sql
+++ b/migrations/2024090204_create_schulungseinladungen.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS schulungseinladungen (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    teilnehmer_id INT NOT NULL,
+    termin DATE NULL,
+    eingeladen_am DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_schulungseinladungen_teilnehmer (teilnehmer_id),
+    CONSTRAINT fk_schulungseinladungen_teilnehmer
+        FOREIGN KEY (teilnehmer_id)
+        REFERENCES schulungsteilnehmer (id)
+        ON DELETE CASCADE
+);

--- a/public/schulungsverwaltung.php
+++ b/public/schulungsverwaltung.php
@@ -89,7 +89,8 @@ function checkUndVersendeEinladungen($termin, $maxEinladungen = 8){
 		}
 	}
 }
-function versendeEinladung($id, $termin){
+function versendeEinladung($id, $termin)
+{
     global $pdo;
 
     /* Teilnehmerdaten holen */
@@ -105,13 +106,25 @@ function versendeEinladung($id, $termin){
         return false;                       // ID nicht gefunden
     }
 
-    $vorname         = $teilnehmer['vorname'];
-    $email           = $teilnehmer['email'];
-    $praxistagdatum  = DateTime::createFromFormat('Y-m-d', $termin)
-                        ->format('d.m.y');
+    $vorname        = $teilnehmer['vorname'];
+    $email          = $teilnehmer['email'];
+    $praxistagdatum = null;
+
+    if (!empty($termin)) {
+        $dateObj = DateTime::createFromFormat('Y-m-d', $termin);
+        if ($dateObj !== false) {
+            $praxistagdatum = $dateObj->format('d.m.y');
+        }
+    }
+
+    if ($praxistagdatum === null) {
+        $praxistagdatum = (new DateTime())->format('d.m.y');
+    }
 
     /* E‑Mail verschicken (versand.php) */
     if (sendInvitation($id, $vorname, $email, $praxistagdatum)) {
+
+        protokolliereEinladung($id, $termin ?: null);
 
         /* Nur noch den Einladungs‑Stempel setzen */
         $update = $pdo->prepare(
@@ -146,9 +159,9 @@ if (isset($_SESSION['user_id'])) {
 }
 
 // Teilnehmer aus der Datenbank abrufen
-$query = "SELECT id, vorname, nachname, 
-                 DATE_FORMAT(erstellt_am, '%d.%m.%Y') AS erstellt_am, 
-                 COALESCE(schulungstermin, '') AS schulungstermin, 
+$query = "SELECT id, vorname, nachname, email,
+                 DATE_FORMAT(erstellt_am, '%d.%m.%Y') AS erstellt_am,
+                 COALESCE(schulungstermin, '') AS schulungstermin,
                  DATE_FORMAT(letzte_einladung, '%d.%m.%Y') AS letzte_einladung,
                  rueckmeldung_status,
                  unternehmer,
@@ -162,6 +175,45 @@ $query = "SELECT id, vorname, nachname,
 $stmt = $pdo->prepare($query);
 $stmt->execute();
 $teilnehmer = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$einladungshistorie = [];
+
+try {
+    $historyQuery = "
+        SELECT
+            teilnehmer_id,
+            DATE_FORMAT(eingeladen_am, '%d.%m.%Y %H:%i') AS eingeladen_am,
+            DATE_FORMAT(termin, '%d.%m.%Y')             AS termin
+        FROM schulungseinladungen
+        ORDER BY eingeladen_am DESC";
+
+    $historyStmt = $pdo->prepare($historyQuery);
+    $historyStmt->execute();
+
+    foreach ($historyStmt->fetchAll(PDO::FETCH_ASSOC) as $historyRow) {
+        $teilnehmerId = (int) $historyRow['teilnehmer_id'];
+
+        if (!isset($einladungshistorie[$teilnehmerId])) {
+            $einladungshistorie[$teilnehmerId] = [];
+        }
+
+        $einladungshistorie[$teilnehmerId][] = [
+            'eingeladen_am' => $historyRow['eingeladen_am'],
+            'termin'        => $historyRow['termin'],
+        ];
+    }
+} catch (PDOException $e) {
+    // Tabelle existiert möglicherweise noch nicht – dann einfach keine Historie anzeigen.
+}
+
+$einladungshistorieJson = json_encode(
+    $einladungshistorie,
+    JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE
+);
+
+if ($einladungshistorieJson === false) {
+    $einladungshistorieJson = '{}';
+}
 
 // Termin speichern
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['termin_speichern'])) {
@@ -345,6 +397,12 @@ include __DIR__ . '/../includes/layout.php';
     <!-- Font Awesome Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
+    <style>
+        [data-participant-row] {
+            cursor: pointer;
+        }
+    </style>
+
         <main>
 		<div class="alert alert-info text-center">
 		<strong>Teilnehmer gesamt:</strong> <?php echo $stats['gesamt']; ?> |
@@ -415,7 +473,9 @@ include __DIR__ . '/../includes/layout.php';
 					</button>
 				</form>
 			</div>
-		 <?php endif; ?>
+                 <?php endif; ?>
+
+        <p class="text-muted small">Tipp: Doppelklick auf einen Teilnehmer zeigt Details zur Einladungshistorie.</p>
 
         <!-- Tabelle mit Teilnehmern -->
         <table class="table table-striped table-hover">
@@ -441,7 +501,19 @@ include __DIR__ . '/../includes/layout.php';
             </thead>
             <tbody>
                 <?php foreach ($teilnehmer as $row): ?>
-                    <tr>
+                    <tr
+                        data-participant-row
+                        data-id="<?php echo (int) $row['id']; ?>"
+                        data-name="<?php echo htmlspecialchars($row['vorname'] . ' ' . $row['nachname'], ENT_QUOTES); ?>"
+                        data-email="<?php echo htmlspecialchars($row['email'], ENT_QUOTES); ?>"
+                        data-unternehmer="<?php echo htmlspecialchars($row['unternehmer'] ?? '', ENT_QUOTES); ?>"
+                        data-schulungstermin="<?php echo htmlspecialchars($row['schulungstermin'] ?? '', ENT_QUOTES); ?>"
+                        data-letzte-einladung="<?php echo htmlspecialchars($row['letzte_einladung'] ?? '', ENT_QUOTES); ?>"
+                        data-rueckmeldung-status="<?php echo htmlspecialchars($row['rueckmeldung_status'] ?? '', ENT_QUOTES); ?>"
+                        data-einladungen-anzahl="<?php echo isset($einladungshistorie[$row['id']]) ? count($einladungshistorie[$row['id']]) : 0; ?>"
+                        data-erstellt-am="<?php echo htmlspecialchars($row['erstellt_am'] ?? '', ENT_QUOTES); ?>"
+                        title="Doppelklick für Details"
+                    >
 						<td>
 							<?php if (!empty($row['gesperrt_bis']) && new DateTime($row['gesperrt_bis']) > new DateTime()): ?>
 								<i class="fas fa-ban text-danger" title="Gesperrt bis <?= date('d.m.y', strtotime($row['gesperrt_bis'])) ?>"></i>
@@ -538,6 +610,24 @@ include __DIR__ . '/../includes/layout.php';
         </table>
     </main>
 
+    <!-- Teilnehmerdetails -->
+    <div class="modal fade" id="participantModal" tabindex="-1" aria-labelledby="participantModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="participantModalLabel">Teilnehmerdetails</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
+          </div>
+          <div class="modal-body" data-participant-modal-body>
+            <p class="text-muted mb-0">Keine Daten vorhanden.</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Schließen</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Löschbestätigungsmodal -->
     <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
       <div class="modal-dialog">
@@ -561,6 +651,118 @@ include __DIR__ . '/../includes/layout.php';
     <!-- Bootstrap JS und Abhängigkeiten -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
+        const participantHistory = <?php echo $einladungshistorieJson ?: '{}'; ?>;
+        const participantRows = document.querySelectorAll('[data-participant-row]');
+        const participantModalElement = document.getElementById('participantModal');
+        const participantModalBody = participantModalElement ? participantModalElement.querySelector('[data-participant-modal-body]') : null;
+        const participantModalTitle = participantModalElement ? participantModalElement.querySelector('.modal-title') : null;
+
+        function normalizeValue(value, fallback = '–') {
+            return value === undefined || value === null || value === '' ? fallback : value;
+        }
+
+        function escapeHtml(value) {
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        function formatDateGerman(value) {
+            if (!value) {
+                return '–';
+            }
+
+            const parts = value.split('-');
+            if (parts.length === 3) {
+                return `${parts[2]}.${parts[1]}.${parts[0]}`;
+            }
+
+            return value;
+        }
+
+        function formatRueckmeldung(status) {
+            if (status === '1') {
+                return 'Teilnahme bestätigt';
+            }
+
+            if (status === '0') {
+                return 'Teilnahme abgelehnt';
+            }
+
+            return 'Keine Rückmeldung';
+        }
+
+        participantRows.forEach(function (row) {
+            row.addEventListener('dblclick', function (event) {
+                if (event.target.closest('a, button, form, input, select, textarea, label')) {
+                    return;
+                }
+
+                if (!participantModalElement || !participantModalBody || !participantModalTitle) {
+                    return;
+                }
+
+                const participantId = row.dataset.id;
+                const participantName = normalizeValue(row.dataset.name, 'Teilnehmer');
+                const participantEmail = normalizeValue(row.dataset.email);
+                const participantUnternehmer = normalizeValue(row.dataset.unternehmer);
+                const participantTermin = formatDateGerman(row.dataset.schulungstermin);
+                const participantLetzteEinladung = normalizeValue(row.dataset.letzteEinladung);
+                const rueckmeldungStatus = formatRueckmeldung(row.dataset.rueckmeldungStatus);
+                const erstelltAm = normalizeValue(row.dataset.erstelltAm);
+                const history = participantHistory[participantId] || [];
+                const invitesCount = history.length;
+
+                const summaryHtml = '<dl class="row mb-0">'
+                    + '<dt class="col-sm-5">E-Mail</dt><dd class="col-sm-7">' + escapeHtml(participantEmail) + '</dd>'
+                    + '<dt class="col-sm-5">Unternehmer</dt><dd class="col-sm-7">' + escapeHtml(participantUnternehmer) + '</dd>'
+                    + '<dt class="col-sm-5">Angemeldet am</dt><dd class="col-sm-7">' + escapeHtml(erstelltAm) + '</dd>'
+                    + '<dt class="col-sm-5">Aktueller Schulungstermin</dt><dd class="col-sm-7">' + escapeHtml(participantTermin) + '</dd>'
+                    + '<dt class="col-sm-5">Letzte Einladung</dt><dd class="col-sm-7">' + escapeHtml(participantLetzteEinladung) + '</dd>'
+                    + '<dt class="col-sm-5">Rückmeldestatus</dt><dd class="col-sm-7">' + escapeHtml(rueckmeldungStatus) + '</dd>'
+                    + '<dt class="col-sm-5">Einladungen gesamt</dt><dd class="col-sm-7">' + invitesCount + '</dd>'
+                    + '</dl>';
+
+                let historyHtml;
+
+                if (history.length === 0) {
+                    historyHtml = '<div class="mt-3">'
+                        + '<h6 class="fw-semibold">Einladungshistorie</h6>'
+                        + '<p class="text-muted mb-0">Bisher wurden keine Einladungen verschickt.</p>'
+                        + '</div>';
+                } else {
+                    const historyRows = history.map(function (entry, index) {
+                        const termin = normalizeValue(entry.termin);
+
+                        return '<tr>'
+                            + '<td class="text-muted">' + (index + 1) + '</td>'
+                            + '<td>' + escapeHtml(normalizeValue(entry.eingeladen_am)) + '</td>'
+                            + '<td>' + escapeHtml(termin) + '</td>'
+                            + '</tr>';
+                    }).join('');
+
+                    historyHtml = '<div class="mt-3">'
+                        + '<h6 class="fw-semibold">Einladungshistorie</h6>'
+                        + '<div class="table-responsive">'
+                        + '<table class="table table-sm align-middle mb-0">'
+                        + '<thead><tr><th class="text-muted" style="width: 4rem;">#</th><th>Versendet am</th><th>Für Praxistag</th></tr></thead>'
+                        + '<tbody>' + historyRows + '</tbody>'
+                        + '</table>'
+                        + '</div>'
+                        + '</div>';
+                }
+
+                participantModalTitle.textContent = 'Teilnehmerdetails – ' + participantName;
+                participantModalBody.innerHTML = summaryHtml + historyHtml;
+
+                const modalInstance = bootstrap.Modal.getOrCreateInstance(participantModalElement);
+                modalInstance.show();
+            });
+        });
+
         // Beim Öffnen des Modals den Teilnehmer-ID in das versteckte Feld schreiben
         var deleteModal = document.getElementById('deleteModal');
         deleteModal.addEventListener('show.bs.modal', function (event) {


### PR DESCRIPTION
## Summary
- add a migration that introduces the `schulungseinladungen` table for invitation history
- record every invitation send in `versand.php` so the history stays up to date
- surface a double-click modal in the Schulungsverwaltung that shows a participant’s invitation count and timeline

## Testing
- php -l public/versand.php
- php -l public/schulungsverwaltung.php

------
https://chatgpt.com/codex/tasks/task_e_68e626a8a08c832b8c590e5e3c3e2228