### PR TITLE
Adjust dashboard widget spacing

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -964,9 +964,9 @@ nav {
 
 .widget {
     background-color: white;
-    margin-top: 12px;
-    margin-bottom: 20px;
-    padding: 20px;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding: 0;
     border-radius: 10px;
     border: 2px solid #FFD700; /* Gelber Rand */
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Schlagschatten */
@@ -984,7 +984,7 @@ nav {
 
 .widget h2 {
     position: absolute;
-    top: -28px;
+    top: -10px;
     left: 20px;
     background-color: #FFD700; /* Gelber Hintergrund */
     color: #333; /* Dunkle Schriftfarbe */


### PR DESCRIPTION
## Summary
- remove extra margin and padding from dashboard widgets for tighter layout
- raise widget titles closer to content by setting top offset to -10px

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e62d44dae0832b8b01e9694e2ee9b6