### PR TITLE
Switch font size units from rem to em

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -13,7 +13,7 @@ html {
 body {
     font-family: var(--font-family-base);
     background-color: var(--body-bg-color);
-    font-size: 1rem;
+    font-size: 1em;
 }
 
 .container {
@@ -59,7 +59,7 @@ body {
     position: absolute;
     top: 10px;
     right: 15px;
-    font-size: 1.5rem;
+    font-size: 1.5em;
 }
 
 .burger-menu span {
@@ -259,7 +259,7 @@ nav {
     display: none;
     background: none;
     border: none;
-    font-size: 1.25rem;
+    font-size: 1.25em;
     color: #ffffff;
     cursor: pointer;
 }
@@ -304,7 +304,7 @@ nav {
     display: inline-block;
     background-color: red;
     color: white;
-    font-size: 0.75rem;
+    font-size: 0.75em;
     font-weight: bold;
     padding: 0.2rem 0.45rem;
     border-radius: 10px;
@@ -552,7 +552,7 @@ input:focus, select:focus {
 .modal .close {
   color: var(--color-primary);
   float: right;
-  font-size: 1rem;
+  font-size: 1em;
   font-weight: bold;
   cursor: pointer;
 }
@@ -607,7 +607,7 @@ input:focus, select:focus {
   text-decoration: none;
   display: block;
   margin-bottom: 10px;
-  font-size: 0.95rem;
+  font-size: 0.95em;
   transition: color 0.2s;
 }
 
@@ -617,7 +617,7 @@ input:focus, select:focus {
 }
 
 .sidebar p {
-  font-size: 0.9rem;
+  font-size: 0.9em;
   line-height: 1.5;
 }
 
@@ -781,7 +781,7 @@ header {
 }
 
 header h1 {
-    font-size: 2.5rem;
+    font-size: 2.5em;
     font-weight: bold;
     margin: 0;
     color: #333;
@@ -790,7 +790,7 @@ header h1 {
 }
 
 header p#subtitle {
-    font-size: 1.2rem;
+    font-size: 1.2em;
     font-weight: 300;
     color: #555;
     margin-top: 10px;
@@ -907,7 +907,7 @@ nav {
     display: none;
     background: none;
     border: none;
-    font-size: 1.25rem;
+    font-size: 1.25em;
     color: #ffffff;
     cursor: pointer;
 }
@@ -950,7 +950,7 @@ nav {
     display: inline-block;
     background-color: red;
     color: white;
-    font-size: 0.75rem;
+    font-size: 0.75em;
     font-weight: bold;
     padding: 0.2rem 0.45rem;
     border-radius: 10px;
@@ -990,7 +990,7 @@ nav {
     color: #333; /* Dunkle Schriftfarbe */
     padding: 5px 15px;
     border-radius: 20px;
-    font-size: 1rem;
+    font-size: 1em;
     font-weight: bold;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
@@ -1011,7 +1011,7 @@ nav {
 }
 
 .department h3 {
-    font-size: 1.05rem;
+    font-size: 1.05em;
     margin-bottom: 10px;
     color: #333;
     text-transform: uppercase;
@@ -1023,7 +1023,7 @@ nav {
 
 #zentraler-dienstplan h3 {
     margin-top: 20px;
-    font-size: 1.4rem;
+    font-size: 1.4em;
 }
 
 #zentraler-dienstplan ul {
@@ -1066,7 +1066,7 @@ button {
     padding: 10px 15px;
     border-radius: 5px;
     cursor: pointer;
-    font-size: 1rem;
+    font-size: 1em;
     transition: background 0.3s ease;
 }
 
@@ -1153,21 +1153,21 @@ button:hover {
 .hero-eyebrow {
     text-transform: uppercase;
     letter-spacing: 0.22em;
-    font-size: 0.75rem;
+    font-size: 0.75em;
     font-weight: 600;
     color: #a07c00;
     margin-bottom: 0.75rem;
 }
 
 .hero-title {
-    font-size: clamp(2.2rem, 2.4vw + 1.2rem, 3.4rem);
+    font-size: clamp(2.2em, 2.4vw + 1.2em, 3.4em);
     font-weight: 700;
     margin-bottom: 0.5rem;
     color: #1f1f1f;
 }
 
 .hero-subtitle {
-    font-size: 1.05rem;
+    font-size: 1.05em;
     color: #4d4d4d;
     margin: 0;
     max-width: 36rem;
@@ -1227,7 +1227,7 @@ button:hover {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.6rem;
+    font-size: 1.6em;
 }
 
 .stat-content {
@@ -1238,14 +1238,14 @@ button:hover {
 
 .stat-label {
     text-transform: uppercase;
-    font-size: 0.78rem;
+    font-size: 0.78em;
     letter-spacing: 0.16em;
     color: #6c757d;
     font-weight: 600;
 }
 
 .stat-value {
-    font-size: 1.85rem;
+    font-size: 1.85em;
     font-weight: 700;
     color: #212529;
 }
@@ -1292,7 +1292,7 @@ button:hover {
 }
 
 .section-title {
-    font-size: 1.3rem;
+    font-size: 1.3em;
     font-weight: 700;
     margin: 0;
     color: #1f1f1f;
@@ -1308,7 +1308,7 @@ button:hover {
 .section-subtitle {
     margin: 0;
     color: #6c757d;
-    font-size: 0.95rem;
+    font-size: 0.95em;
 }
 
 .company-card {
@@ -1330,7 +1330,7 @@ button:hover {
 
 .company-title {
     margin: 0;
-    font-size: 1.1rem;
+    font-size: 1.1em;
     font-weight: 600;
     color: #1f1f1f;
 }
@@ -1348,7 +1348,7 @@ button:hover {
 }
 
 .info-title {
-    font-size: 1.05rem;
+    font-size: 1.05em;
     font-weight: 600;
     margin: 0;
     display: flex;
@@ -1391,7 +1391,7 @@ button:hover {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
-    font-size: 0.9rem;
+    font-size: 0.9em;
     color: #495057;
 }
 
@@ -1402,7 +1402,7 @@ button:hover {
 }
 
 .list-meta {
-    font-size: 0.82rem;
+    font-size: 0.82em;
     color: #6c757d;
     display: inline-flex;
     align-items: center;
@@ -1411,7 +1411,7 @@ button:hover {
 
 .dashboard-table thead th {
     text-transform: uppercase;
-    font-size: 0.78rem;
+    font-size: 0.78em;
     letter-spacing: 0.08em;
     background: #f8f9fa;
     border-bottom: 2px solid #e9ecef;

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -93,7 +93,7 @@ button[type="submit"] {
   border: none;
   border-radius: 4px;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 1em;
   cursor: pointer;
   transition: background-color 0.3s ease;
 }

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -57,7 +57,7 @@
 }
 
 .messages-container .timestamp {
-    font-size: 0.8rem;
+    font-size: 0.8em;
     color: #666;
 }
 
@@ -151,7 +151,7 @@
 
 .message-meta {
     margin: 0.25rem 0 0 0;
-    font-size: 0.75rem;
+    font-size: 0.75em;
     color: #666;
 }
 

--- a/public/driver/css/driver-dashboard.css
+++ b/public/driver/css/driver-dashboard.css
@@ -68,7 +68,7 @@ button:hover {
 
 .gesamtumsatz {
     text-align: center;
-    font-size: 1.2rem;
+    font-size: 1.2em;
     font-weight: bold;
     padding: 10px;
     background: #ffeb3b;
@@ -88,7 +88,7 @@ button:hover {
     text-align: left;
     padding: 10px;
     border: 1px solid #ddd;
-    font-size: 1rem;
+    font-size: 1em;
 }
 
 .umsatz-tabelle th {
@@ -109,7 +109,7 @@ button:hover {
     text-decoration: none;
     padding: 5px 15px;
     border-radius: 5px;
-    font-size: 0.9rem;
+    font-size: 0.9em;
     font-weight: bold;
     color: #fff;
     transition: background-color 0.3s;


### PR DESCRIPTION
## Summary
- convert font-size declarations in the main custom stylesheet from rem to em, including responsive hero typography
- update driver dashboard, messaging, and index styles to use em units for font sizes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63295f8dc832b9c25d890cb797e2c