### PR TITLE
Add global costum stylesheet inclusion

### DIFF
--- a/public/css/costum.css
+++ b/public/css/costum.css
@@ -1,0 +1,9 @@
+/*
+ * Zusätzliche anpassbare Styles können hier eingefügt werden.
+ * Diese Datei wird global auf allen Seiten eingebunden.
+ */
+
+/* Beispiel: Grundlegende Layout-Anpassungen */
+body {
+    /* Platzhalterregel: Entfernen oder anpassen, sobald echte Styles benötigt werden. */
+}

--- a/public/head.php
+++ b/public/head.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/../includes/bootstrap.php';
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="stylesheet" href="css/custom.css?v=<?= filemtime(__DIR__ . '/css/custom.css'); ?>">
+    <link rel="stylesheet" href="css/costum.css?v=<?= file_exists(__DIR__ . '/css/costum.css') ? filemtime(__DIR__ . '/css/costum.css') : time(); ?>">
     <?php
     if (!empty($extraCss)) {
         foreach ((array) $extraCss as $css) {


### PR DESCRIPTION
## Summary
- include the new `css/costum.css` stylesheet in the shared head template so every public page loads it
- add a placeholder `costum.css` file for future global styling adjustments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6360c5e80832b9b097af0950a0358