### PR TITLE
Reduce default heading and base font sizes

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -3,7 +3,7 @@
     --secondary-color: var(--bs-secondary);
     --font-family-base: var(--bs-body-font-family);
     --body-bg-color: var(--bs-body-bg);
-    --font-size-base: 0.95rem;
+    --font-size-base: 0.9rem;
 }
 
 html {
@@ -15,6 +15,16 @@ body {
     font-family: var(--font-family-base);
     background-color: var(--body-bg-color);
     font-size: var(--font-size-base);
+}
+
+.h1, h1 {
+    font-size: clamp(1.75rem, 3vw, 2.15rem);
+}
+
+@media (min-width: 1200px) {
+    .h1, h1 {
+        font-size: 2.15rem;
+    }
 }
 
 .container {


### PR DESCRIPTION
## Summary
- decrease the global base font size token to reduce overall text scale
- add explicit heading sizing to clamp values and shrink large screen h1 styles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e648f473fc832b9998e6f97c0fafce