### PR TITLE
Füge Schichtfarben im Zentrale-Dashboard hinzu

### DIFF
--- a/public/zentrale_dashboard.php
+++ b/public/zentrale_dashboard.php
@@ -324,10 +324,31 @@ include __DIR__ . '/../includes/layout.php';
 									}
 								}
 
-								// Schicht prüfen, nur wenn kein Urlaub
-								if ($cellText === '-' && isset($dienstplanMap[$person['mitarbeiter_id']][$date['date']])) {
-									$cellText = $dienstplanMap[$person['mitarbeiter_id']][$date['date']];
-								}
+                                                                // Schicht prüfen, nur wenn kein Urlaub
+                                                                if ($cellText === '-' && isset($dienstplanMap[$person['mitarbeiter_id']][$date['date']])) {
+                                                                        $cellText = $dienstplanMap[$person['mitarbeiter_id']][$date['date']];
+                                                                }
+
+                                                                // Farben für Schichten wie im Dashboard setzen, falls keine Abwesenheit
+                                                                if ($cellClass === '' && $cellText !== '-' && isset($dienstplanMap[$person['mitarbeiter_id']][$date['date']])) {
+                                                                        switch ($cellText) {
+                                                                                case 'F0':
+                                                                                case 'F1':
+                                                                                case 'F3':
+                                                                                        $cellClass = 'early-shift';
+                                                                                        break;
+                                                                                case 'F2':
+                                                                                        $cellClass = 'mid-shift';
+                                                                                        break;
+                                                                                case 'S0':
+                                                                                case 'S1':
+                                                                                        $cellClass = 'late-shift';
+                                                                                        break;
+                                                                                case 'N':
+                                                                                        $cellClass = 'night-shift';
+                                                                                        break;
+                                                                        }
+                                                                }
 								?>
 								<td class="<?php echo $cellClass; ?>">
 									<?php echo htmlspecialchars($cellText); ?>


### PR DESCRIPTION
## Summary
- ergänze im Zentrale-Dashboard die gleiche Farbzuweisung für Schichten wie im Haupt-Dashboard
- sorge dafür, dass Schichtfarben nur angezeigt werden, wenn keine Abwesenheitsklasse greift

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e649fccbdc832b8dd0f1a362a8d619